### PR TITLE
fix: onClosePanel should be called before onItemClick

### DIFF
--- a/src/components/AsideHeader/AsideHeader.tsx
+++ b/src/components/AsideHeader/AsideHeader.tsx
@@ -86,7 +86,7 @@ export class AsideHeader extends React.Component<AsideHeaderInnerProps> {
                             compact={compact}
                             enableCollapsing={true}
                             dict={dict}
-                            onItemClick={this.onCompositeBarClick}
+                            onItemClick={this.onItemClick}
                         />
                         {this.renderFooter(size)}
                         {this.renderCollapseButton()}
@@ -118,6 +118,7 @@ export class AsideHeader extends React.Component<AsideHeaderInnerProps> {
                 items={this.props.subheaderItems}
                 compact={this.props.compact}
                 enableCollapsing={false}
+                onItemClick={this.onItemClick}
             />
 
             <Icon
@@ -189,7 +190,8 @@ export class AsideHeader extends React.Component<AsideHeaderInnerProps> {
         this.props.onClosePanel?.();
     };
 
-    private onCompositeBarClick = () => {
+    private onItemClick = (item: MenuItem, collapsed: boolean) => {
         this.props.onClosePanel?.();
+        item.onItemClick?.(item, collapsed);
     };
 }

--- a/src/components/AsideHeader/__stories__/AsideHeaderShowcase.scss
+++ b/src/components/AsideHeader/__stories__/AsideHeaderShowcase.scss
@@ -70,6 +70,7 @@ body {
         height: 100%;
     }
 
+    &__components-panel,
     &__settings-panel,
     &__search-panel {
         width: 300px;

--- a/src/components/AsideHeader/__stories__/AsideHeaderShowcase.tsx
+++ b/src/components/AsideHeader/__stories__/AsideHeaderShowcase.tsx
@@ -16,6 +16,7 @@ enum Panel {
     ProjectSettings = 'projectSettings',
     Search = 'search',
     UserSettings = 'userSettings',
+    Components = 'components',
 }
 
 export function AsideHeaderShowcase() {
@@ -35,7 +36,20 @@ export function AsideHeaderShowcase() {
                     href: '#',
                     onClick: () => alert('click on logo'),
                 }}
-                menuItems={menuItemsShowcase}
+                menuItems={[
+                    ...menuItemsShowcase,
+                    {
+                        id: 'components',
+                        title: 'Components',
+                        icon: menuItemIcon,
+                        current: visiblePanel === Panel.Components,
+                        iconSize: 20,
+                        onItemClick: () =>
+                            setVisiblePanel(
+                                visiblePanel === Panel.Components ? undefined : Panel.Components,
+                            ),
+                    },
+                ]}
                 subheaderItems={[
                     {
                         id: 'services',
@@ -154,6 +168,11 @@ export function AsideHeaderShowcase() {
                         id: 'user-settings',
                         content: <div className={b('settings-panel')}>User Settings</div>,
                         visible: visiblePanel === Panel.UserSettings,
+                    },
+                    {
+                        id: 'components',
+                        content: <div className={b('components-panel')}>Components</div>,
+                        visible: visiblePanel === Panel.Components,
                     },
                 ]}
                 onClosePanel={() => setVisiblePanel(undefined)}

--- a/src/components/CompositeBar/CompositeBar.tsx
+++ b/src/components/CompositeBar/CompositeBar.tsx
@@ -20,7 +20,7 @@ export interface CompositeBarProps {
     compact: boolean;
     enableCollapsing: boolean;
     dict?: AsideHeaderDict;
-    onItemClick?: (item: MenuItem) => void;
+    onItemClick?: (item: MenuItem, collapsed: boolean) => void;
 }
 
 interface CompositeBarState {
@@ -79,7 +79,6 @@ export class CompositeBar extends React.Component<CompositeBarProps> {
                 virtualized={false}
                 filterable={false}
                 sortable={false}
-                onItemClick={onItemClick}
                 renderItem={(item) => (
                     <Item
                         item={item}
@@ -90,6 +89,7 @@ export class CompositeBar extends React.Component<CompositeBarProps> {
                         }}
                         compact={compact}
                         collapseItems={collapseItems}
+                        onItemClick={onItemClick}
                     />
                 )}
             />
@@ -110,7 +110,6 @@ export class CompositeBar extends React.Component<CompositeBarProps> {
                 virtualized={false}
                 filterable={false}
                 sortable={false}
-                onItemClick={onItemClick}
                 renderItem={(item) => (
                     <Item
                         item={item}
@@ -120,6 +119,7 @@ export class CompositeBar extends React.Component<CompositeBarProps> {
                             }
                         }}
                         compact={compact}
+                        onItemClick={onItemClick}
                     />
                 )}
             />

--- a/src/components/CompositeBar/Item/Item.tsx
+++ b/src/components/CompositeBar/Item/Item.tsx
@@ -30,6 +30,7 @@ interface ItemPopup {
 export interface ItemProps extends ItemPopup {
     item: MenuItem;
     enableTooltip?: boolean;
+    onItemClick?: (item: MenuItem, collapsed: boolean) => void;
 }
 
 interface ItemInnerProps extends ItemProps {
@@ -72,6 +73,7 @@ export const Item: React.FC<ItemInnerProps> = ({
     popupOffset = defaultPopupOffset,
     renderPopupContent,
     onClosePopup,
+    onItemClick,
 }) => {
     if (item.type === 'divider') {
         return <div className={b('menu-divider')} />;
@@ -109,12 +111,16 @@ export const Item: React.FC<ItemInnerProps> = ({
             className={b({type, current, compact}, className)}
             ref={ref}
             onClick={() => {
-                if (typeof item.onItemClick === 'function') {
-                    item.onItemClick(item, false);
-                }
                 if (collapsedItem) {
+                    /**
+                     * If we call onItemClick for collapsedItem then:
+                     * - User get unexpected item in onItemClick callback
+                     * - onClosePanel calls twice for each popuped item, as result it will prevent opening of panelItems
+                     */
                     toggleOpen(!open);
                     setTooltipAnchor(null);
+                } else {
+                    onItemClick?.(item, false);
                 }
             }}
             onMouseEnter={() => {
@@ -181,9 +187,7 @@ export const Item: React.FC<ItemInnerProps> = ({
                                     <div
                                         className={b('collapse-item')}
                                         onClick={() => {
-                                            if (typeof collapseItem.onItemClick === 'function') {
-                                                collapseItem.onItemClick(collapseItem, true);
-                                            }
+                                            onItemClick?.(collapseItem, true);
                                         }}
                                     >
                                         {renderItemTitle(collapseItem)}

--- a/src/components/FooterItem/FooterItem.tsx
+++ b/src/components/FooterItem/FooterItem.tsx
@@ -8,7 +8,7 @@ import './FooterItem.scss';
 
 const b = block('footer-item');
 
-export interface FooterItemProps extends ItemProps {
+export interface FooterItemProps extends Omit<ItemProps, 'onItemClick'> {
     compact: boolean;
 }
 
@@ -18,6 +18,7 @@ export const FooterItem: React.FC<FooterItemProps> = ({item, ...props}) => {
             {...props}
             item={{iconSize: ASIDE_HEADER_FOOTER_ICON_SIZE, ...item}}
             className={b({compact: props.compact})}
+            onItemClick={item.onItemClick}
         />
     );
 };


### PR DESCRIPTION
https://preview.yandexcloud.dev/navigation/23/?path=/story/components-asideheader--showcase
To test the fix try to click on 'Components' menu item (below 'Dashboard'). 
The corresponding panel should be opened correctly whether you click on 'Search' from popup (under 'More') or not.