### PR TITLE
fix: keep svg viewbox

### DIFF
--- a/svgo.config.js
+++ b/svgo.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+    plugins: [
+        {
+            name: 'preset-default',
+            params: {
+                overrides: {
+                    removeViewBox: false,
+                },
+            },
+        },
+    ],
+};


### PR DESCRIPTION
how the collapse icon should look (screenshot from storybook, where development build is used)
![image](https://user-images.githubusercontent.com/3864424/209993516-59447eed-f2b7-487b-b203-fb7191090104.png)

how does it look using production build:
![image](https://user-images.githubusercontent.com/3864424/209993703-4ac94ee0-ce08-41a7-bd3b-0c3cb192418f.png)
the arrow is smaller and shifted to the left

the difference between builds is viewbox, svgo removes it in production build

this PR adds svgo config to preserve viewboxes