### PR TITLE
feat(Settings): Added selection feature to the Settings

### DIFF
--- a/src/components/Settings/Selection/context.ts
+++ b/src/components/Settings/Selection/context.ts
@@ -1,0 +1,33 @@
+import React from 'react';
+import {SelectedSettingsPart, SettingsPage, getSelectedSettingsPart} from '../collect-settings';
+import {SettingsSelection} from './types';
+
+interface ContextValue extends SelectedSettingsPart {
+    selectedRef?: React.RefObject<HTMLDivElement>;
+}
+
+const defaultValue: ContextValue = {};
+
+const context = React.createContext(defaultValue);
+context.displayName = 'SettingsSelectionContext';
+
+export function useSettingsSelectionProviderValue(
+    pages: Record<string, SettingsPage>,
+    selection: SettingsSelection | undefined,
+): ContextValue {
+    const selectedRef = React.useRef<HTMLDivElement>(null);
+
+    const contextValue: ContextValue = React.useMemo(() => {
+        if (!selection) return {selectedRef};
+
+        return {selectedRef, ...getSelectedSettingsPart(pages, selection)};
+    }, [pages, selection]);
+
+    return contextValue;
+}
+
+export const SettingsSelectionContextProvider = context.Provider;
+
+export function useSettingsSelectionContext() {
+    return React.useContext(context);
+}

--- a/src/components/Settings/Selection/index.ts
+++ b/src/components/Settings/Selection/index.ts
@@ -1,0 +1,2 @@
+export * from './context';
+export * from './types';

--- a/src/components/Settings/Selection/types.ts
+++ b/src/components/Settings/Selection/types.ts
@@ -1,0 +1,5 @@
+export interface SettingsSelection {
+    page?: string;
+    section?: {id: string} | {title: string};
+    settingId?: string;
+}

--- a/src/components/Settings/Selection/utils.ts
+++ b/src/components/Settings/Selection/utils.ts
@@ -1,0 +1,21 @@
+import {SelectedSettingsPart, SettingsPageSection} from '../collect-settings';
+
+export function isSectionSelected(
+    selected: SelectedSettingsPart,
+    pageId: string,
+    section: SettingsPageSection,
+) {
+    if (!selected.section || selected.setting) {
+        return false;
+    } else if (selected.section.id && selected.section.id === section.id) {
+        return true;
+    } else if (
+        selected.page?.id === pageId &&
+        selected.section.title &&
+        selected.section.title === section.title
+    ) {
+        return true;
+    } else {
+        return false;
+    }
+}

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -150,6 +150,14 @@ $block: '.#{variables.$ns}settings';
     }
 
     &__section {
+        &-right-adornment_hidden {
+            opacity: 0;
+            transition: opacity 0.2s;
+        }
+        &-heading:hover &-right-adornment_hidden {
+            opacity: 1;
+        }
+
         &-heading {
             @include text-subheader-2;
             margin: 0;
@@ -210,6 +218,14 @@ $block: '.#{variables.$ns}settings';
         &:hover &-right-adornment_hidden {
             opacity: 1;
         }
+    }
+
+    &__item_selected,
+    &__section_selected {
+        background: var(--g-color-base-selection);
+        padding: 8px;
+        border-radius: 8px;
+        margin-left: -8px;
     }
 
     &__found {

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -9,11 +9,22 @@ import {SettingsMenuMobile} from './SettingsMenuMobile/SettingsMenuMobile';
 import {Title} from '../Title';
 import i18n from './i18n';
 
-import type {SettingsMenu as SettingsMenuType} from './collect-settings';
+import type {
+    SettingsItem,
+    SettingsMenu as SettingsMenuType,
+    SettingsPageSection,
+} from './collect-settings';
 import {getSettingsFromChildren} from './collect-settings';
 import {escapeStringForRegExp} from './helpers';
 
 import './Settings.scss';
+import {
+    SettingsSelectionContextProvider,
+    useSettingsSelectionContext,
+    useSettingsSelectionProviderValue,
+} from './Selection/context';
+import {SettingsSelection} from './Selection';
+import {isSectionSelected} from './Selection/utils';
 
 const b = block('settings');
 
@@ -24,13 +35,15 @@ export interface SettingsProps {
     emptyPlaceholder?: string;
     initialPage?: string;
     initialSearch?: string;
+    selection?: SettingsSelection;
     onPageChange?: (page: string | undefined) => void;
     renderNotFound?: () => React.ReactNode;
     renderLoading?: () => React.ReactNode;
     loading?: boolean;
     view?: 'normal' | 'mobile';
     onClose?: () => void;
-    renderRightAdornment?: (item: Pick<SettingsItemProps, 'title'>) => React.ReactNode;
+    renderRightAdornment?: (item: SettingsItemProps) => React.ReactNode;
+    renderSectionRightAdornment?: (section: SettingsPageSection) => React.ReactNode;
     showRightAdornmentOnHover?: boolean;
 }
 
@@ -48,6 +61,7 @@ export interface SettingsPageProps {
 }
 
 export interface SettingsSectionProps {
+    id?: string;
     title: string;
     header?: React.ReactNode;
     children: React.ReactNode;
@@ -56,6 +70,7 @@ export interface SettingsSectionProps {
 }
 
 export interface SettingsItemProps {
+    id?: string;
     title: string;
     highlightedTitle?: React.ReactNode | null;
     renderTitleComponent?: (highlightedTitle: React.ReactNode | null) => React.ReactNode;
@@ -67,7 +82,10 @@ export interface SettingsItemProps {
 }
 
 export interface SettingsContextType
-    extends Pick<SettingsProps, 'renderRightAdornment' | 'showRightAdornmentOnHover'> {}
+    extends Pick<
+        SettingsProps,
+        'renderRightAdornment' | 'renderSectionRightAdornment' | 'showRightAdornmentOnHover'
+    > {}
 
 const SettingsContext = React.createContext<SettingsContextType>({});
 
@@ -79,6 +97,7 @@ export function Settings({
     children,
     view = 'normal',
     renderRightAdornment,
+    renderSectionRightAdornment,
     showRightAdornmentOnHover = true,
     ...props
 }: SettingsProps) {
@@ -95,7 +114,9 @@ export function Settings({
     }
 
     return (
-        <SettingsContext.Provider value={{renderRightAdornment, showRightAdornmentOnHover}}>
+        <SettingsContext.Provider
+            value={{renderRightAdornment, renderSectionRightAdornment, showRightAdornmentOnHover}}
+        >
             <SettingsContent view={view} {...props}>
                 {children}
             </SettingsContent>
@@ -118,6 +139,7 @@ type SettingsContentProps = Omit<SettingsProps, 'loading' | 'renderLoading'>;
 function SettingsContent({
     initialPage,
     initialSearch,
+    selection,
     children,
     renderNotFound,
     title = i18n('label_title'),
@@ -127,11 +149,19 @@ function SettingsContent({
     onPageChange,
     onClose,
 }: SettingsContentProps) {
+    const {renderSectionRightAdornment, showRightAdornmentOnHover} = useSettingsContext();
+
     const [search, setSearch] = React.useState(initialSearch ?? '');
     const {menu, pages} = getSettingsFromChildren(children, search);
+
+    const selected = useSettingsSelectionProviderValue(pages, selection);
+
     const pageKeys = Object.keys(pages);
+    const selectionInitialPage =
+        selected.page && pageKeys.includes(selected.page.id) ? selected.page.id : undefined;
     const [selectedPage, setCurrentPage] = React.useState<string | undefined>(
-        initialPage && pageKeys.includes(initialPage) ? initialPage : undefined,
+        selectionInitialPage ||
+            (initialPage && pageKeys.includes(initialPage) ? initialPage : undefined),
     );
     const searchInputRef = React.useRef<HTMLInputElement>(null);
     const menuRef = React.useRef<SettingsMenuInstance>(null);
@@ -171,8 +201,71 @@ function SettingsContent({
         }
     });
 
-    const renderPageContent = () => {
-        if (!activePage) {
+    React.useEffect(() => {
+        if (!selectionInitialPage) return;
+        setCurrentPage(selectionInitialPage);
+    }, [selectionInitialPage]);
+
+    React.useEffect(() => {
+        if (!selected.selectedRef?.current) return;
+
+        selected.selectedRef.current.scrollIntoView();
+    }, [selected.selectedRef]);
+
+    const renderSetting = ({title: settingTitle, element}: SettingsItem) => {
+        return (
+            <div key={settingTitle} className={b('section-item')}>
+                {React.cloneElement(element, {
+                    ...element.props,
+                    highlightedTitle:
+                        search && settingTitle ? prepareTitle(settingTitle, search) : settingTitle,
+                })}
+            </div>
+        );
+    };
+
+    const renderSection = (page: string, section: SettingsPageSection) => {
+        const isSelected = isSectionSelected(selected, page, section);
+
+        return (
+            <div
+                key={section.title}
+                className={b('section', {selected: isSelected})}
+                ref={isSelected ? selected.selectedRef : undefined}
+            >
+                {section.showTitle && (
+                    <h3 className={b('section-heading')}>
+                        {renderSectionRightAdornment ? (
+                            <Flex gap={2} alignItems={'center'}>
+                                {section.title}
+                                <div
+                                    className={b('section-right-adornment', {
+                                        hidden: showRightAdornmentOnHover,
+                                    })}
+                                >
+                                    {renderSectionRightAdornment(section)}
+                                </div>
+                            </Flex>
+                        ) : (
+                            section.title
+                        )}
+                    </h3>
+                )}
+
+                {section.header &&
+                    (isMobile ? (
+                        <div className={b('section-subheader')}>{section.header}</div>
+                    ) : (
+                        section.header
+                    ))}
+
+                {section.items.map((setting) => (setting.hidden ? null : renderSetting(setting)))}
+            </div>
+        );
+    };
+
+    const renderPageContent = (page: string | undefined) => {
+        if (!page) {
             return typeof renderNotFound === 'function' ? (
                 renderNotFound()
             ) : (
@@ -180,104 +273,79 @@ function SettingsContent({
             );
         }
 
-        const filteredSections = pages[activePage].sections.filter((section) => !section.hidden);
+        const filteredSections = pages[page].sections.filter((section) => !section.hidden);
 
         return (
             <>
                 {!isMobile && (
                     <Title hasSeparator onClose={onClose}>
-                        {getPageTitleById(menu, activePage)}
+                        {getPageTitleById(menu, page)}
                     </Title>
                 )}
 
                 <div className={b('content')}>
-                    {filteredSections.map((section) => (
-                        <div key={section.title} className={b('section')}>
-                            {section.showTitle && (
-                                <h3 className={b('section-heading')}>{section.title}</h3>
-                            )}
-
-                            {section.header &&
-                                (isMobile ? (
-                                    <div className={b('section-subheader')}>{section.header}</div>
-                                ) : (
-                                    section.header
-                                ))}
-
-                            {section.items.map(({hidden, title, element}) =>
-                                hidden ? null : (
-                                    <div key={title} className={b('section-item')}>
-                                        {React.cloneElement(element, {
-                                            ...element.props,
-                                            highlightedTitle:
-                                                search && title
-                                                    ? prepareTitle(title, search)
-                                                    : title,
-                                        })}
-                                    </div>
-                                ),
-                            )}
-                        </div>
-                    ))}
+                    {filteredSections.map((section) => renderSection(page, section))}
                 </div>
             </>
         );
     };
 
     return (
-        <div className={b({view})}>
-            {isMobile ? (
-                <>
-                    <SettingsSearch
-                        inputRef={searchInputRef}
-                        className={b('search')}
-                        initialValue={initialSearch}
-                        onChange={setSearch}
-                        autoFocus={false}
-                        inputSize={'xl'}
-                    />
-                    <SettingsMenuMobile
-                        items={menu}
-                        onChange={handlePageChange}
-                        activeItemId={activePage}
-                        className={b('tabs')}
-                    />
-                </>
-            ) : (
-                <div
-                    className={b('menu')}
-                    onClick={() => {
-                        if (searchInputRef.current) {
-                            searchInputRef.current.focus();
-                        }
-                    }}
-                    onKeyDown={(event) => {
-                        if (menuRef.current) {
-                            if (menuRef.current.handleKeyDown(event)) {
-                                event.preventDefault();
+        <SettingsSelectionContextProvider value={selected}>
+            <div className={b({view})}>
+                {isMobile ? (
+                    <>
+                        <SettingsSearch
+                            inputRef={searchInputRef}
+                            className={b('search')}
+                            initialValue={initialSearch}
+                            onChange={setSearch}
+                            autoFocus={false}
+                            inputSize={'xl'}
+                        />
+                        <SettingsMenuMobile
+                            items={menu}
+                            onChange={handlePageChange}
+                            activeItemId={activePage}
+                            className={b('tabs')}
+                        />
+                    </>
+                ) : (
+                    <div
+                        className={b('menu')}
+                        onClick={() => {
+                            if (searchInputRef.current) {
+                                searchInputRef.current.focus();
                             }
-                        }
-                    }}
-                >
-                    <Title>{title}</Title>
-                    <SettingsSearch
-                        inputRef={searchInputRef}
-                        className={b('search')}
-                        initialValue={initialSearch}
-                        onChange={setSearch}
-                        placeholder={filterPlaceholder}
-                        autoFocus
-                    />
-                    <SettingsMenu
-                        ref={menuRef}
-                        items={menu}
-                        onChange={handlePageChange}
-                        activeItemId={activePage}
-                    />
-                </div>
-            )}
-            <div className={b('page')}>{renderPageContent()}</div>
-        </div>
+                        }}
+                        onKeyDown={(event) => {
+                            if (menuRef.current) {
+                                if (menuRef.current.handleKeyDown(event)) {
+                                    event.preventDefault();
+                                }
+                            }
+                        }}
+                    >
+                        <Title>{title}</Title>
+                        <SettingsSearch
+                            inputRef={searchInputRef}
+                            className={b('search')}
+                            initialValue={initialSearch}
+                            onChange={setSearch}
+                            placeholder={filterPlaceholder}
+                            autoFocus
+                        />
+                        <SettingsMenu
+                            ref={menuRef}
+                            items={menu}
+                            onChange={handlePageChange}
+                            activeItemId={activePage}
+                        />
+                    </div>
+                )}
+                <div className={b('page')}>{renderPageContent(activePage)}</div>
+            </div>
+        </SettingsSelectionContextProvider>
     );
 }
 
@@ -293,16 +361,21 @@ Settings.Section = function SettingsSection({children}: SettingsSectionProps) {
     return <React.Fragment>{children}</React.Fragment>;
 };
 
-Settings.Item = function SettingsItem({
-    title,
-    highlightedTitle,
-    children,
-    align = 'center',
-    withBadge,
-    renderTitleComponent = identity,
-    mode,
-    description,
-}: SettingsItemProps) {
+Settings.Item = function SettingsItem(setting: SettingsItemProps) {
+    const {
+        id,
+        highlightedTitle,
+        children,
+        align = 'center',
+        withBadge,
+        renderTitleComponent = identity,
+        mode,
+        description,
+    } = setting;
+
+    const selected = useSettingsSelectionContext();
+    const isSettingSelected = selected.setting && selected.setting.id === id;
+
     const {renderRightAdornment, showRightAdornmentOnHover} = useSettingsContext();
     const titleNode = (
         <span className={b('item-title', {badge: withBadge})}>
@@ -310,7 +383,10 @@ Settings.Item = function SettingsItem({
         </span>
     );
     return (
-        <div className={b('item', {align, mode})}>
+        <div
+            className={b('item', {align, mode, selected: isSettingSelected})}
+            ref={isSettingSelected ? selected.selectedRef : undefined}
+        >
             <label className={b('item-heading')}>
                 {renderRightAdornment ? (
                     <Flex className={b('item-title-wrapper')} gap={3}>
@@ -320,7 +396,7 @@ Settings.Item = function SettingsItem({
                                 hidden: showRightAdornmentOnHover,
                             })}
                         >
-                            {renderRightAdornment({title})}
+                            {renderRightAdornment(setting)}
                         </div>
                     </Flex>
                 ) : (

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -208,9 +208,9 @@ function SettingsContent({
     }, [selectionInitialPage]);
 
     React.useEffect(() => {
-        if (!selected.selectedRef?.current) return;
-
-        selected.selectedRef.current.scrollIntoView();
+        if (selected.selectedRef?.current) {
+            selected.selectedRef.current.scrollIntoView();
+        }
     }, [selected.selectedRef]);
 
     const renderSetting = ({title: settingTitle, element}: SettingsItem) => {

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -17,14 +17,15 @@ import type {
 import {getSettingsFromChildren} from './collect-settings';
 import {escapeStringForRegExp} from './helpers';
 
-import './Settings.scss';
+import {SettingsSelection} from './Selection';
 import {
     SettingsSelectionContextProvider,
     useSettingsSelectionContext,
     useSettingsSelectionProviderValue,
 } from './Selection/context';
-import {SettingsSelection} from './Selection';
 import {isSectionSelected} from './Selection/utils';
+
+import './Settings.scss';
 
 const b = block('settings');
 

--- a/src/components/Settings/__stories__/SettingsDemo.tsx
+++ b/src/components/Settings/__stories__/SettingsDemo.tsx
@@ -7,8 +7,9 @@ import {Button, Switch, Checkbox, RadioButton, Radio, Select, Link} from '@gravi
 import featureIcon from '../../../../assets/icons/gear.svg';
 import {cn} from '../../utils/cn';
 
-import './SettingsDemo.scss';
 import {SettingsSelection} from '../Selection/types';
+
+import './SettingsDemo.scss';
 
 export interface DemoProps {
     title: string;

--- a/src/components/Settings/__stories__/SettingsDemo.tsx
+++ b/src/components/Settings/__stories__/SettingsDemo.tsx
@@ -2,12 +2,13 @@ import React, {useReducer} from 'react';
 
 import {Settings} from '../index';
 import {HelpPopover} from '@gravity-ui/components';
-import {Button, Switch, Checkbox, RadioButton, Radio, Select} from '@gravity-ui/uikit';
+import {Button, Switch, Checkbox, RadioButton, Radio, Select, Link} from '@gravity-ui/uikit';
 
 import featureIcon from '../../../../assets/icons/gear.svg';
 import {cn} from '../../utils/cn';
 
 import './SettingsDemo.scss';
+import {SettingsSelection} from '../Selection/types';
 
 export interface DemoProps {
     title: string;
@@ -60,17 +61,25 @@ export const SettingsComponent = React.memo(
         const handleChange = (name: string, value: any) => {
             dispatch(setSetting(name, value));
         };
+
+        const [selection, setSelection] = React.useState<SettingsSelection | undefined>(undefined);
+
         return (
             <Settings
                 initialPage={initialPage}
                 onPageChange={(page) => {
                     console.log({page});
+                    setSelection(undefined);
                 }}
                 onClose={onClose}
                 renderRightAdornment={({title}) => (
                     <HelpPopover content={`Some text for ${title}`} />
                 )}
+                renderSectionRightAdornment={({title}) => (
+                    <HelpPopover content={`Some text for ${title}`} />
+                )}
                 showRightAdornmentOnHover={true} // true by default
+                selection={selection}
             >
                 <Settings.Group id="arcanum" groupTitle="Arcanum">
                     <Settings.Page id="features" title="Features" icon={{data: featureIcon}}>
@@ -91,8 +100,30 @@ export const SettingsComponent = React.memo(
                                     }}
                                 />
                             </Settings.Item>
+                            <Settings.Item title="Go to setting">
+                                <Link
+                                    onClick={() =>
+                                        setSelection({settingId: 'arcanum-theme-setting'})
+                                    }
+                                >
+                                    Go to «Arcanum/Appearance/Appearance/Theme»
+                                </Link>
+                            </Settings.Item>
+                            <Settings.Item title="Go to section">
+                                <Link
+                                    onClick={() =>
+                                        setSelection({section: {id: 'arcanum-common-section'}})
+                                    }
+                                >
+                                    Go to «Arcanum/Features/Common»
+                                </Link>
+                            </Settings.Item>
                         </Settings.Section>
-                        <Settings.Section title="Common" withBadge={withBadge}>
+                        <Settings.Section
+                            id={'arcanum-common-section'}
+                            title="Common"
+                            withBadge={withBadge}
+                        >
                             <Settings.Item
                                 title="Default VCS"
                                 description={
@@ -134,6 +165,7 @@ export const SettingsComponent = React.memo(
                             }
                         >
                             <Settings.Item
+                                id="arcanum-theme-setting"
                                 title="Theme"
                                 renderTitleComponent={(highlightedTitle) => (
                                     <div>


### PR DESCRIPTION
### What's new

It is now possible to select a setting, a section or a page in the Settings component.
Here's how it looks.

### Setting

<img width="865" alt="image" src="https://github.com/gravity-ui/navigation/assets/18216279/06b0de95-0cd7-4326-805e-2b1dde17164f">

### Section

<img width="865" alt="image" src="https://github.com/gravity-ui/navigation/assets/18216279/fb7a05c5-8579-4afa-8d4a-5362a97cef65">

### Page

Nothing fancy here — it just changes current page.

### Storybook

You can try it out in the storybook — I added two links for selecting a setting and a section.

![image](https://github.com/gravity-ui/navigation/assets/18216279/ed220689-013e-4f24-9386-11fa32a338ad)

### Possible usage

This can be used for settings links in URLs.
For example, one may add a button for copying a link to a setting using the `renderRightAdornment` property and after someone opens the page with the right link, we can open `Settings` with the needed selection through the use of `React.useEffect`.

### One more thing

I also added an optional `id` property to `SettingsItemProps` and `SettingsSectionProps` (and also `SettingsItem` and `SettingsPageSection`).