### PR TITLE
fix: multiple-tooltip backgroud styles precedence

### DIFF
--- a/src/components/CompositeBar/MultipleTooltip/MultipleTooltip.scss
+++ b/src/components/CompositeBar/MultipleTooltip/MultipleTooltip.scss
@@ -27,8 +27,10 @@ $block: '.#{variables.$ns}multiple-tooltip';
 }
 
 #{$block} {
-    background-color: transparent;
-    box-shadow: none;
+    &#{&} {
+        background-color: transparent;
+        box-shadow: none;
+    }
 
     &::before {
         content: '';


### PR DESCRIPTION
Due to different import order popup__content styles can take precedence over multiple-tooltip style. 
Added more specifity to multiple-tooltip selector to fix it.