### PR TITLE
fix(MultipleTooltip): changed tooltips and it's backdrop styles

### DIFF
--- a/src/components/CompositeBar/MultipleTooltip/MultipleTooltip.scss
+++ b/src/components/CompositeBar/MultipleTooltip/MultipleTooltip.scss
@@ -2,8 +2,9 @@
 
 $block: '.#{variables.$ns}multiple-tooltip';
 
-.g-root_theme_dark,
-.g-root_theme_dark-hc {
+.g-root_theme_dark #{$block},
+.g-root_theme_dark-hc #{$block} {
+    // TODO: Replace private color variable with special one which should appear in next uikit major version
     --multiple-tooltip-item-bg-color: var(--g-color-private-white-100-solid);
     --multiple-tooltip-item-active-bg-color: var(--g-color-base-float-heavy);
     --multiple-tooltip-backdrop-background: linear-gradient(
@@ -14,12 +15,14 @@ $block: '.#{variables.$ns}multiple-tooltip';
     --multiple-tooltip-backdrop-filter: blur(16px);
 }
 
-.g-root_theme_dark-hc {
+.g-root_theme_dark-hc #{$block} {
+    // TODO: Replace private color variable with special one which should appear in next uikit major version
     --multiple-tooltip-item-bg-color: var(--g-color-private-white-150-solid);
 }
 
 .g-root_theme_light #{$block},
 .g-root_theme_light-hc #{$block} {
+    // TODO: Replace private color variable with special one which should appear in next uikit major version
     --multiple-tooltip-item-bg-color: var(--g-color-private-black-550-solid);
     --multiple-tooltip-item-active-bg-color: var(--g-color-base-float-heavy);
     --multiple-tooltip-backdrop-background: linear-gradient(

--- a/src/components/CompositeBar/MultipleTooltip/MultipleTooltip.scss
+++ b/src/components/CompositeBar/MultipleTooltip/MultipleTooltip.scss
@@ -2,26 +2,30 @@
 
 $block: '.#{variables.$ns}multiple-tooltip';
 
-.g-root_theme_dark #{$block},
-.g-root_theme_dark-hc #{$block} {
-    --multiple-tooltip-item-bg-color: #424147; // TODO: color variable will appear in uikit 5
+.g-root_theme_dark,
+.g-root_theme_dark-hc {
+    --multiple-tooltip-item-bg-color: var(--g-color-private-white-100-solid);
     --multiple-tooltip-item-active-bg-color: var(--g-color-base-float-heavy);
     --multiple-tooltip-backdrop-background: linear-gradient(
         90deg,
-        #313036 0%,
-        rgba(49, 48, 54, 0.3) 100%
+        var(--g-color-base-background) 50%,
+        transparent
     );
     --multiple-tooltip-backdrop-filter: blur(16px);
 }
 
+.g-root_theme_dark-hc {
+    --multiple-tooltip-item-bg-color: var(--g-color-private-white-150-solid);
+}
+
 .g-root_theme_light #{$block},
 .g-root_theme_light-hc #{$block} {
-    --multiple-tooltip-item-bg-color: #7a7a7a; // TODO: color variable will appear in uikit 5
+    --multiple-tooltip-item-bg-color: var(--g-color-private-black-550-solid);
     --multiple-tooltip-item-active-bg-color: var(--g-color-base-float-heavy);
     --multiple-tooltip-backdrop-background: linear-gradient(
         90deg,
-        #ffffff 0%,
-        rgba(255, 255, 255, 0.3) 100%
+        var(--g-color-base-background) 50%,
+        transparent
     );
     --multiple-tooltip-backdrop-filter: blur(12px);
 }
@@ -39,6 +43,7 @@ $block: '.#{variables.$ns}multiple-tooltip';
         width: 100%;
         height: 100%;
         z-index: -1;
+        opacity: 0.7;
         background: var(--multiple-tooltip-backdrop-background);
         filter: var(--multiple-tooltip-backdrop-filter);
     }


### PR DESCRIPTION
Hi

In this PR, I propose to change the tooltip styles

1. The background color of the tooltip itself has been changed with the help of the product design team.
2. Backdrop style is suggested to correct the wrong appearance in different themes.

As a basic idea, I took the background color variable and made a gradient.

| Before (AS IS) | After (TO BE) |
|--------|--------|
| <img width="610" alt="image" src="https://github.com/gravity-ui/navigation/assets/2071148/20887b18-80c5-4b17-bc3c-8669aee3afb4"> | <img width="610" alt="image" src="https://github.com/gravity-ui/navigation/assets/2071148/651852fc-38fc-49d3-988f-7b524bd2ea52"> |
| <img width="610" alt="image" src="https://github.com/gravity-ui/navigation/assets/2071148/8da07b8e-abf1-4ad2-9d7f-797a19a34520"> | <img width="610" alt="image" src="https://github.com/gravity-ui/navigation/assets/2071148/02359f5f-ba65-4fc6-80c1-df849a8bba0e"> | 