### PR TITLE
fix(Footer): fix warning with setState on unmounted component

### DIFF
--- a/src/hooks/useOverflowingHorizontalListItems/useOverflowingHorizontalListItems.ts
+++ b/src/hooks/useOverflowingHorizontalListItems/useOverflowingHorizontalListItems.ts
@@ -41,7 +41,7 @@ export function useOverflowingHorizontalListItems<ItemType>({
         }
 
         const updateContainerSize = (entries: ResizeObserverEntry[]) => {
-            if (entries.length > 0) {
+            if (entries.length > 0 && footerMenu) {
                 setContainerWidth(entries[0].contentRect.width);
             }
         };


### PR DESCRIPTION
Due to the debounce function, there may be a warning
![2024-04-27_13-34-51](https://github.com/gravity-ui/navigation/assets/56549651/5ca8be9f-dbf6-48ba-80b8-178a51fdf85a)
