### PR TITLE
chore(rollup): Add CSS Extraction to Rollup Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "main": "build/cjs",
   "module": "build/esm",
   "types": "build/esm/index.d.ts",
+  "exports": {
+    "./styles.css": "./build/esm/index.css"
+  },
   "sideEffects": [
     "*.css",
     "*.scss"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,7 +36,9 @@ const getPlugins = (outDir) => {
             outDir,
         }),
         postcss({
+            extract: true,
             minimize: true,
+            use: ['sass'],
         }),
         svgr(),
     ];


### PR DESCRIPTION
In this PR, I have updated the Rollup configuration to extract CSS files from SCSS sources using the rollup-plugin-postcss. The primary goal is to improve the usability of the package for ssr projects by allowing users to directly import a pre-compiled CSS file.

## Notes

This implementation could be considered a temporary solution to address immediate integration challenges.
