### PR TITLE
feat(Drawer): add resize classname

### DIFF
--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -90,7 +90,7 @@ export const DrawerItem = React.forwardRef<HTMLDivElement, DrawerItemProps>(
 
         const cssDirection = direction === 'left' ? undefined : direction;
 
-        const {resizedWidth, resizerHandlers} = useResizableDrawerItem({
+        const {resizedWidth, resizerHandlers, isResizing} = useResizableDrawerItem({
             direction,
             width,
             minResizeWidth,
@@ -124,7 +124,11 @@ export const DrawerItem = React.forwardRef<HTMLDivElement, DrawerItemProps>(
                     ref={handleRef}
                     className={b(
                         'item',
-                        {direction: cssDirection, hidden: isInitialRender && !visible},
+                        {
+                            direction: cssDirection,
+                            hidden: isInitialRender && !visible,
+                            resize: isResizing,
+                        },
                         [className],
                     )}
                     style={{width: resizable ? `${resizedWidth}px` : undefined}}

--- a/src/components/Drawer/utils.ts
+++ b/src/components/Drawer/utils.ts
@@ -149,5 +149,5 @@ export function useResizableDrawerItem(params: UseResizableDrawerItemParams) {
 
     const handlers = useResizeHandlers({onStart, onMove, onEnd});
 
-    return {resizedWidth: displayWidth, resizerHandlers: handlers};
+    return {resizedWidth: displayWidth, resizerHandlers: handlers, isResizing};
 }


### PR DESCRIPTION
Add `gn-drawer__item_direction_resize` classname to detect resizing. It's useful when you want to disable overflow, change user-select or add some styles