### PR TITLE
fix: added DOMProps & QAProps to ActionBar components

### DIFF
--- a/src/components/ActionBar/ActionBar.tsx
+++ b/src/components/ActionBar/ActionBar.tsx
@@ -1,5 +1,7 @@
 import React, {PropsWithChildren} from 'react';
 
+import {DOMProps, QAProps} from '@gravity-ui/uikit';
+
 import {block} from '../utils/cn';
 
 import {ActionBarGroup} from './Group/ActionBarGroup';
@@ -9,16 +11,17 @@ import {ActionBarSeparator} from './Separator/ActionBarSeparator';
 
 import './ActionBar.scss';
 
-export type Props = PropsWithChildren<{
-    'aria-label'?: string;
-    className?: string;
-}>;
+export type Props = DOMProps &
+    QAProps &
+    PropsWithChildren<{
+        'aria-label'?: string;
+    }>;
 
 const b = block('action-bar');
 
-const ActionBar = ({children, className, 'aria-label': ariaLabel}: Props) => {
+const ActionBar = ({children, className, style, qa, 'aria-label': ariaLabel}: Props) => {
     return (
-        <section className={b(null, className)} aria-label={ariaLabel}>
+        <section className={b(null, className)} style={style} aria-label={ariaLabel} data-qa={qa}>
             {children}
         </section>
     );

--- a/src/components/ActionBar/Group/ActionBarGroup.tsx
+++ b/src/components/ActionBar/Group/ActionBarGroup.tsx
@@ -1,22 +1,30 @@
 import React, {PropsWithChildren} from 'react';
 
+import {DOMProps, QAProps} from '@gravity-ui/uikit';
+
 import {block} from '../../utils/cn';
 import {PropsWithPull} from '../types';
 
 import './ActionBarGroup.scss';
 
-export type Props = PropsWithChildren<
-    PropsWithPull<{
-        className?: string;
-        stretchContainer?: boolean;
-    }>
->;
+export type Props = DOMProps &
+    QAProps &
+    PropsWithChildren<
+        PropsWithPull<{
+            stretchContainer?: boolean;
+        }>
+    >;
 
 const b = block('action-bar-group');
 
-export const ActionBarGroup = ({children, className, pull, stretchContainer}: Props) => {
+export const ActionBarGroup = ({children, className, style, qa, pull, stretchContainer}: Props) => {
     return (
-        <ul className={b({pull, 'stretch-container': stretchContainer}, className)} role="group">
+        <ul
+            className={b({pull, 'stretch-container': stretchContainer}, className)}
+            role="group"
+            style={style}
+            data-qa={qa}
+        >
             {children}
         </ul>
     );

--- a/src/components/ActionBar/Item/ActionBarItem.tsx
+++ b/src/components/ActionBar/Item/ActionBarItem.tsx
@@ -1,22 +1,25 @@
 import React, {PropsWithChildren} from 'react';
 
+import {DOMProps, QAProps} from '@gravity-ui/uikit';
+
 import {block} from '../../utils/cn';
 import {PropsWithPull} from '../types';
 
 import './ActionBarItem.scss';
 
-export type Props = PropsWithChildren<
-    PropsWithPull<{
-        spacing?: boolean;
-        className?: string;
-    }>
->;
+export type Props = DOMProps &
+    QAProps &
+    PropsWithChildren<
+        PropsWithPull<{
+            spacing?: boolean;
+        }>
+    >;
 
 const b = block('action-bar-item');
 
-export const ActionBarItem = ({children, className, pull, spacing = true}: Props) => {
+export const ActionBarItem = ({children, className, style, qa, pull, spacing = true}: Props) => {
     return (
-        <li className={b({pull, spacing}, className)} role="menuitem">
+        <li className={b({pull, spacing}, className)} style={style} role="menuitem" data-qa={qa}>
             {children}
         </li>
     );

--- a/src/components/ActionBar/README.md
+++ b/src/components/ActionBar/README.md
@@ -46,10 +46,12 @@ The `ActionBar` provides several nested components that work together to create 
 
 ## Properties
 
-| Name       | Description                 |   Type   | Default |
-| :--------- | :-------------------------- | :------: | :-----: |
-| aria-label | HTML `aria-label` attribute | `string` |         |
-| className  | HTML `class` attribute      | `string` |         |
+| Name       | Description                                |         Type          | Default |
+| :--------- | :----------------------------------------- | :-------------------: | :-----: |
+| aria-label | HTML `aria-label` attribute                |       `string`        |         |
+| className  | HTML `class` attribute                     |       `string`        |         |
+| style      | HTML `style` attribute                     | `React.CSSProperties` |         |
+| qa         | `data-qa` HTML attribute, used for testing |       `string`        |         |
 
 ## ActionBar.Section
 
@@ -60,9 +62,12 @@ horizontal separator from `primary` section.
 
 ### Properties
 
-| Name | Description                                      |            Type            |   Default   |
-| :--- | :----------------------------------------------- | :------------------------: | :---------: |
-| type | Type specifies the visual styling of the section | `"primary"`, `"secondary"` | `"primary"` |
+| Name      | Description                                      |            Type            |   Default   |
+| :-------- | :----------------------------------------------- | :------------------------: | :---------: |
+| type      | Type specifies the visual styling of the section | `"primary"`, `"secondary"` | `"primary"` |
+| className | HTML `class` attribute                           |          `string`          |             |
+| style     | HTML `style` attribute                           |   `React.CSSProperties`    |             |
+| qa        | `data-qa` HTML attribute, used for testing       |          `string`          |             |
 
 <!--GITHUB_BLOCK-->
 
@@ -107,9 +112,11 @@ Groups organize `ActionBar.Item` within a section and control their alignment.
 
 | Name             | Description                                                       |                                      Type                                       | Default |
 | :--------------- | :---------------------------------------------------------------- | :-----------------------------------------------------------------------------: | :-----: |
-| className        | HTML `class` attribute                                            |                                    `string`                                     |         |
 | pull             | Controls the alignment of the group                               | `"left"`, `"left-grow"`, `"right"`, `"right-grow"`, `"center"`, `"center-grow"` |         |
 | stretchContainer | Set `flex-grow: 1` for Group. Need to support UIKit@7 Breadcrumbs |                                    `boolean`                                    |         |
+| className        | HTML `class` attribute                                            |                                    `string`                                     |         |
+| style            | HTML `style` attribute                                            |                              `React.CSSProperties`                              |         |
+| qa               | `data-qa` HTML attribute, used for testing                        |                                    `string`                                     |         |
 
 ## ActionBar.Item
 
@@ -117,10 +124,12 @@ Container for UI elements like buttons, breadcrumbs or other components must be 
 
 ### Properties
 
-| Name      | Description                       |   Type    | Default |
-| :-------- | :-------------------------------- | :-------: | :-----: |
-| className | HTML `class` attribute            | `string`  |         |
-| spacing   | Enable spacing with previous item | `boolean` | `true`  |
+| Name      | Description                                |         Type          | Default |
+| :-------- | :----------------------------------------- | :-------------------: | :-----: |
+| spacing   | Enable spacing with previous item          |       `boolean`       | `true`  |
+| className | HTML `class` attribute                     |       `string`        |         |
+| style     | HTML `style` attribute                     | `React.CSSProperties` |         |
+| qa        | `data-qa` HTML attribute, used for testing |       `string`        |         |
 
 ## ActionBar.Separator
 

--- a/src/components/ActionBar/Section/ActionBarSection.tsx
+++ b/src/components/ActionBar/Section/ActionBarSection.tsx
@@ -1,16 +1,18 @@
 import React, {PropsWithChildren} from 'react';
 
+import {DOMProps, QAProps} from '@gravity-ui/uikit';
+
 import {block} from '../../utils/cn';
 
 import './ActionBarSection.scss';
 
-export type Props = PropsWithChildren<{type?: 'primary' | 'secondary'}>;
+export type Props = DOMProps & QAProps & PropsWithChildren<{type?: 'primary' | 'secondary'}>;
 
 const b = block('action-bar-section');
 
-export const ActionBarSection = ({children, type = 'primary'}: Props) => {
+export const ActionBarSection = ({children, className, style, qa, type = 'primary'}: Props) => {
     return (
-        <div className={b({type})} role="menu">
+        <div className={b({type}, className)} style={style} role="menu" data-qa={qa}>
             {children}
         </div>
     );


### PR DESCRIPTION
`ActionBarSection` was lacking `className` property. And I need a className or style prop there in order to add `overflow: hidden;` to the section

So I decided to add `DOMProps & QAProps` to all of the `ActionBar` components