### PR TITLE
fix(dataui-3175):  hydration error in AsideHeader

### DIFF
--- a/src/components/AsideHeader/components/FirstPanel.tsx
+++ b/src/components/AsideHeader/components/FirstPanel.tsx
@@ -12,7 +12,7 @@ import {CollapseButton} from './CollapseButton/CollapseButton';
 import {Header} from './Header';
 import {Panels} from './Panels';
 
-const MENU_ITEMS_COMPOSITE_ID = 'gravity-ui/navigation-menu-items-compoiste-bar';
+const MENU_ITEMS_COMPOSITE_ID = 'gravity-ui/navigation-menu-items-composite-bar';
 
 export const FirstPanel = React.forwardRef<HTMLDivElement>((_props, ref) => {
     const {

--- a/src/components/AsideHeader/components/FirstPanel.tsx
+++ b/src/components/AsideHeader/components/FirstPanel.tsx
@@ -12,6 +12,8 @@ import {CollapseButton} from './CollapseButton/CollapseButton';
 import {Header} from './Header';
 import {Panels} from './Panels';
 
+const MENU_ITEMS_COMPOSITE_ID = 'gravity-ui/navigation-menu-items-compoiste-bar';
+
 export const FirstPanel = React.forwardRef<HTMLDivElement>((_props, ref) => {
     const {
         size,
@@ -50,6 +52,7 @@ export const FirstPanel = React.forwardRef<HTMLDivElement>((_props, ref) => {
                     <Header />
                     {visibleMenuItems?.length ? (
                         <CompositeBar
+                            compositeId={MENU_ITEMS_COMPOSITE_ID}
                             type="menu"
                             items={visibleMenuItems}
                             menuMoreTitle={menuMoreTitle ?? i18n('label_more')}

--- a/src/components/AsideHeader/components/Header.tsx
+++ b/src/components/AsideHeader/components/Header.tsx
@@ -12,7 +12,7 @@ import {b} from '../utils';
 import headerDividerCollapsedIcon from '../../../../assets/icons/divider-collapsed.svg';
 
 const DEFAULT_SUBHEADER_ITEMS: SubheaderMenuItem[] = [];
-const HEADER_COMPOSITE_ID = 'gravity-ui/navigation-header-compoiste-bar';
+const HEADER_COMPOSITE_ID = 'gravity-ui/navigation-header-composite-bar';
 
 export const Header = () => {
     const {logo, onItemClick, onClosePanel, headerDecoration, subheaderItems} =

--- a/src/components/AsideHeader/components/Header.tsx
+++ b/src/components/AsideHeader/components/Header.tsx
@@ -12,6 +12,7 @@ import {b} from '../utils';
 import headerDividerCollapsedIcon from '../../../../assets/icons/divider-collapsed.svg';
 
 const DEFAULT_SUBHEADER_ITEMS: SubheaderMenuItem[] = [];
+const HEADER_COMPOSITE_ID = 'gravity-ui/navigation-header-compoiste-bar';
 
 export const Header = () => {
     const {logo, onItemClick, onClosePanel, headerDecoration, subheaderItems} =
@@ -39,6 +40,7 @@ export const Header = () => {
             )}
 
             <CompositeBar
+                compositeId={HEADER_COMPOSITE_ID}
                 type="subheader"
                 items={subheaderItems || DEFAULT_SUBHEADER_ITEMS}
                 onItemClick={onItemClick}

--- a/src/components/CompositeBar/CompositeBar.tsx
+++ b/src/components/CompositeBar/CompositeBar.tsx
@@ -40,10 +40,12 @@ export type CompositeBarProps = CompositeBarItems & {
     multipleTooltip?: boolean;
     menuMoreTitle?: string;
     onMoreClick?: () => void;
+    compositeId?: string;
 };
 
 type CompositeBarViewProps = CompositeBarProps & {
     collapseItems?: MenuItem[];
+    compositeId?: string;
 };
 
 const CompositeBarView: FC<CompositeBarViewProps> = ({
@@ -53,6 +55,7 @@ const CompositeBarView: FC<CompositeBarViewProps> = ({
     onMoreClick,
     collapseItems,
     multipleTooltip = false,
+    compositeId,
 }) => {
     const ref = useRef<List<CompositeBarItem>>(null);
     const tooltipRef = useRef<HTMLDivElement>(null);
@@ -195,6 +198,7 @@ const CompositeBarView: FC<CompositeBarViewProps> = ({
                 onMouseLeave={onTooltipMouseLeave}
             >
                 <List<CompositeBarItem>
+                    id={compositeId}
                     ref={ref}
                     items={items}
                     selectedItemIndex={type === 'menu' ? getSelectedItemIndex(items) : undefined}
@@ -243,6 +247,7 @@ export const CompositeBar: FC<CompositeBarProps> = ({
     onItemClick,
     onMoreClick,
     multipleTooltip = false,
+    compositeId,
 }) => {
     if (items.length === 0) {
         return null;
@@ -268,6 +273,7 @@ export const CompositeBar: FC<CompositeBarProps> = ({
                             return (
                                 <div style={{width, height}}>
                                     <CompositeBarView
+                                        compositeId={compositeId}
                                         type="menu"
                                         items={listItems}
                                         onItemClick={onItemClick}


### PR DESCRIPTION
The `AsideHeader` uses the `CompositeBar`, which is based on the `List` component from `@gravity-ui/uikit`. The `List` generates a unique `id` used for the `id` of each list item. An error may occur during hydration if the `IDs` of the elements do not match due to the fact that the `List` generates its own `IDs`. Therefore, explicit `IDs` have been added to the `Header` and `firstPanel` for the `CompositeBar`.