### PR TITLE
chore(ci): commit version and tag after previous stable release

### DIFF
--- a/.github/workflows/release-previous-stable.yml
+++ b/.github/workflows/release-previous-stable.yml
@@ -22,8 +22,10 @@ jobs:
                       echo "version_type must be defined"
                       exit 1
                   fi
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/checkout@v4
+              with:
+                  token: ${{ secrets.GRAVITY_UI_BOT_GITHUB_TOKEN }}
+            - uses: actions/setup-node@v4
               with:
                   node-version: 18
                   registry-url: 'https://registry.npmjs.org'
@@ -81,3 +83,11 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GRAVITY_UI_BOT_NPM_TOKEN }}
               shell: bash
+            - name: Commit version and create tag
+              run: |
+                git config user.name "gravity-ui-bot"
+                git config user.email "gravity-ui-bot@users.noreply.github.com"
+                git add package.json package-lock.json
+                git commit -m "chore(v${{ env.PUBLISH_VERSION_MAJOR }}): release ${{ env.PUBLISH_VERSION }}"
+                git tag "v${{ env.PUBLISH_VERSION }}"
+                git push origin HEAD --tags

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -14,21 +14,34 @@ const config: TestRunnerConfig = {
         // Get the entire context of a story, including parameters, args, argTypes, etc.
         const storyContext = await getStoryContext(page, context);
 
-        // Apply story-level a11y rules
-        await configureAxe(page, {
-            rules: storyContext.parameters?.a11y?.config?.rules,
-            reporter: 'no-passes',
-        });
+        const MAX_RETRIES = 1;
 
-        // hack for prevent error "Axe is already running"
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-        await checkA11y(page, '#storybook-root', {
-            verbose: false,
-            detailedReport: true,
-            detailedReportOptions: {
-                html: true,
-            },
-        });
+        for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                // Apply story-level a11y rules
+                await configureAxe(page, {
+                    rules: storyContext.parameters?.a11y?.config?.rules,
+                    reporter: 'no-passes',
+                });
+
+                await checkA11y(page, '#storybook-root', {
+                    verbose: false,
+                    detailedReport: true,
+                    detailedReportOptions: {
+                        html: true,
+                    },
+                });
+
+                break;
+            } catch (error) {
+                // Retry if axe was still running from a previous story (e.g. after navigation retry)
+                const isAxeRunning = String(error).includes('Axe is already running');
+                if (!isAxeRunning || attempt === MAX_RETRIES) {
+                    throw error;
+                }
+                await injectAxe(page);
+            }
+        }
     },
 };
 


### PR DESCRIPTION
## Summary
- Updated `actions/checkout` and `actions/setup-node` to v4
- Added checkout with bot token to allow pushing to protected branches
- Added a step that commits updated `package.json` / `package-lock.json` and creates a git tag after npm publish