### PR TITLE
fix(AsideHeader): prevent Drawer veil from overlapping topAlert

### DIFF
--- a/src/components/AsideHeader/AsideHeader.module.scss
+++ b/src/components/AsideHeader/AsideHeader.module.scss
@@ -205,18 +205,12 @@ $block: '.#{variables.$ns}aside-header';
 
     &__panels {
         z-index: var(--gn-aside-header-panel-z-index, 98);
-
-        &,
-        &:global(.g-drawer) {
-            position: fixed;
-            inset: var(--gn-top-alert-height, 0) 0 0;
-        }
     }
 
     &__panel {
         &,
         &:global(.g-drawer__item) {
-            top: var(--gn-top-alert-height, 0);
+            top: 0;
             bottom: 0;
             height: auto;
         }

--- a/src/components/AsideHeader/components/Panels.tsx
+++ b/src/components/AsideHeader/components/Panels.tsx
@@ -16,7 +16,7 @@ export const Panels = () => {
                     key={id}
                     className={b('panels')}
                     onOpenChange={(open) => !open && onClosePanel?.()}
-                    style={{left: size}}
+                    style={{left: size, top: 'var(--gn-top-alert-height, 0px)'}}
                     contentClassName={b('panel', className)}
                 />
             ))}


### PR DESCRIPTION
FloatingOverlay sets `top: 0` as an inline style, which always overrides CSS class rules. Pass `top: var(--gn-top-alert-height, 0px)` via the Drawer style prop to override the default.

Remove the dead `inset` rule on `__panels` and the redundant `top: var(--gn-top-alert-height)` on `__panel` to avoid double offset.