### PR TITLE
fix(AsideHeader): prevent Drawer veil from overlapping topAlert

### DIFF
--- a/src/components/AsideHeader/AsideHeader.module.scss
+++ b/src/components/AsideHeader/AsideHeader.module.scss
@@ -270,18 +270,12 @@ $block: '.#{variables.$ns}aside-header';
 
     &__panels {
         z-index: var(--gn-aside-header-panel-z-index, 98);
-
-        &,
-        &:global(.g-drawer) {
-            position: fixed;
-            inset: var(--gn-top-alert-height, 0) 0 0;
-        }
     }
 
     &__panel {
         &,
         &:global(.g-drawer__item) {
-            top: var(--gn-top-alert-height, 0);
+            top: 0;
             bottom: 0;
             height: auto;
         }

--- a/src/components/AsideHeader/components/Panels.tsx
+++ b/src/components/AsideHeader/components/Panels.tsx
@@ -37,7 +37,7 @@ export const Panels: React.FC = () => {
                     key={id}
                     className={b('panels')}
                     onOpenChange={handleOpenChange}
-                    style={{left: size}}
+                    style={{left: size, top: 'var(--gn-top-alert-height, 0px)'}}
                     contentClassName={b('panel', className)}
                 >
                     {children}


### PR DESCRIPTION
## Summary
- `FloatingOverlay` from `@floating-ui/react` sets `top: 0` as an inline style, which always overrides CSS class rules. The existing `inset: var(--gn-top-alert-height, 0) 0 0` on `__panels` was dead CSS.
- Pass `top: var(--gn-top-alert-height, 0px)` via the Drawer `style` prop in `Panels.tsx` to override the FloatingOverlay default.
- Remove the dead `inset` rule on `__panels` and change `top: var(--gn-top-alert-height, 0)` to `top: 0` on `__panel` to avoid double offset (the parent Drawer now handles the offset).

## Test plan
- [ ] Open any panel (services, settings, favorites) with `topAlert` present — veil should start strictly below the alert
- [ ] Verify panels work correctly without `topAlert` (fallback `0px`)
- [ ] Close `topAlert` while a panel is open — panel should adjust

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout positioning of side panels to properly account for the top alert bar height, ensuring panels display correctly and maintain consistent spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->