### PR TITLE
fix(AsideHeader): preserve consumer-provided style on Drawer panels

### DIFF
--- a/src/components/AsideHeader/components/Panels.tsx
+++ b/src/components/AsideHeader/components/Panels.tsx
@@ -31,13 +31,13 @@ export const Panels: React.FC = () => {
 
     return panelItems ? (
         <React.Fragment>
-            {panelItems.map(({id, className, children, ...rest}) => (
+            {panelItems.map(({id, className, children, style: itemStyle, ...rest}) => (
                 <Drawer
                     {...rest}
                     key={id}
                     className={b('panels')}
                     onOpenChange={handleOpenChange}
-                    style={{left: size, top: 'var(--gn-top-alert-height, 0px)'}}
+                    style={{...itemStyle, left: size, top: 'var(--gn-top-alert-height, 0px)'}}
                     contentClassName={b('panel', className)}
                 >
                     {children}


### PR DESCRIPTION
## Summary
- The Drawer `style` prop in `Panels.tsx` was overwriting any consumer-provided `style` from `panelItems` with hard-coded `{left: size, top: ...}`.
- Destructure `style` as `itemStyle` and spread it before applying the required `left`/`top` positioning values, so consumer styles for other properties are preserved.

## Test plan
- [ ] Verify consumer-provided style properties on panelItems are preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Panel styling now preserves individual item styles while ensuring panels remain correctly positioned (fixed left/top), preventing custom per-item styles from being lost.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->