### PR TITLE
fix(AsideHeader): preserve consumer-provided style on Drawer panels

### DIFF
--- a/src/components/AsideHeader/components/Panels.tsx
+++ b/src/components/AsideHeader/components/Panels.tsx
@@ -10,13 +10,13 @@ export const Panels = () => {
 
     return panelItems ? (
         <React.Fragment>
-            {panelItems.map(({id, className, ...rest}) => (
+            {panelItems.map(({id, className, style: itemStyle, ...rest}) => (
                 <Drawer
                     {...rest}
                     key={id}
                     className={b('panels')}
                     onOpenChange={(open) => !open && onClosePanel?.()}
-                    style={{left: size, top: 'var(--gn-top-alert-height, 0px)'}}
+                    style={{...itemStyle, left: size, top: 'var(--gn-top-alert-height, 0px)'}}
                     contentClassName={b('panel', className)}
                 />
             ))}


### PR DESCRIPTION
## Summary
- The Drawer `style` prop in `Panels.tsx` was overwriting any consumer-provided `style` from `panelItems` with hard-coded `{left: size, top: ...}`.
- Destructure `style` as `itemStyle` and spread it before applying the required `left`/`top` positioning values, so consumer styles for other properties are preserved.

## Test plan
- [ ] Verify consumer-provided style properties on panelItems are preserved