### PR TITLE
chore(ci): add optional latest tag for previous stable release

### DIFF
--- a/.github/workflows/release-previous-stable.yml
+++ b/.github/workflows/release-previous-stable.yml
@@ -5,89 +5,101 @@
 name: Release previous major version
 
 on:
-    workflow_dispatch:
-        inputs:
-            version_type:
-                type: choice
-                description: Select type of version for release
-                options:
-                    - patch
-                    - minor
+  workflow_dispatch:
+    inputs:
+      version_type:
+        type: choice
+        description: Select type of version for release
+        options:
+          - patch
+          - minor
+      set_latest:
+        type: boolean
+        required: false
+        default: false
+        description: Set npm latest tag to the published version
 jobs:
-    build:
-        runs-on: ubuntu-latest
-        steps:
-            - run: |
-                  if [ "${{ github.event.inputs.version_type }}" == "" ]; then
-                      echo "version_type must be defined"
-                      exit 1
-                  fi
-            - uses: actions/checkout@v4
-              with:
-                  token: ${{ secrets.GRAVITY_UI_BOT_GITHUB_TOKEN }}
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: 18
-                  registry-url: 'https://registry.npmjs.org'
-            - run: npm ci
-              shell: bash
-            - run: npm test
-              shell: bash
-            - name: Get package versions
-              id: npm_versions
-              run: |
-                  npm_view_output=$(npm view . versions --json | tr -d '\n ')
-                  echo ${npm_view_output}
-                  echo "npm_versions=${npm_view_output}" >> $GITHUB_OUTPUT
-            - name: Bump and commit version
-              uses: actions/github-script@v7
-              with:
-                  script: |
-                      const allVersions = JSON.parse(process.env.VERSIONS).reverse();
-                      // Filter only stable versions (exclude beta, alpha, rc, etc.)
-                      const versions = allVersions.filter(v => !v.includes('-'));
-                      if (versions.length === 0) {
-                        throw Error("No stable versions found");
-                      }
-                      const currMajor = versions[0].split(".")[0];
-                      const prevVersion = versions.find(v => !v.startsWith(`${currMajor}.`));
-                      if (!prevVersion) {
-                        throw Error("Previous major versions not found");
-                      }
-                      const versionParts = prevVersion.split(".");
-                      if (versionParts.length !== 3) {
-                        throw Error(`Cannot parse version ${prevVersion}`);
-                      }
-                      if (process.env.VERSION_TYPE === "minor") {
-                        versionParts[1] = `${Number(versionParts[1])+1}`;
-                      }
-                      else {
-                        versionParts[2] = `${Number(versionParts[2])+1}`;
-                      }
-                      const newVersion = versionParts.join(".");
-                      core.info(`New version: ${newVersion}`);
-                      try {
-                        core.exportVariable('PUBLISH_VERSION', newVersion);
-                        core.exportVariable('PUBLISH_VERSION_MAJOR', versionParts[0]);
-                      } catch (error) {
-                        core.setFailed(error.message);
-                      }
-              env:
-                  VERSION_TYPE: ${{ github.event.inputs.version_type }}
-                  VERSIONS: ${{ steps.npm_versions.outputs.npm_versions }}
-            - name: Set version
-              run: |
-                npm version ${{ env.PUBLISH_VERSION }} --git-tag-version=false
-            - name: Publish version
-              run: npm publish --tag stable-v${{ env.PUBLISH_VERSION_MAJOR }} --access public
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.GRAVITY_UI_BOT_NPM_TOKEN }}
-              shell: bash
-            - name: Commit version and create tag
-              run: |
-                git config user.name "gravity-ui-bot"
-                git config user.email "gravity-ui-bot@users.noreply.github.com"
-                git add package.json package-lock.json
-                git commit -m "chore(v${{ env.PUBLISH_VERSION_MAJOR }}): release ${{ env.PUBLISH_VERSION }}"
-                git tag "v${{ env.PUBLISH_VERSION }}"
-                git push origin HEAD --tags
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [ "${{ github.event.inputs.version_type }}" == "" ]; then
+              echo "version_type must be defined"
+              exit 1
+          fi
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GRAVITY_UI_BOT_GITHUB_TOKEN }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+        shell: bash
+      - run: npm test
+        shell: bash
+      - name: Get package versions
+        id: npm_versions
+        run: |
+          npm_view_output=$(npm view . versions --json | tr -d '\n ')
+          echo ${npm_view_output}
+          echo "npm_versions=${npm_view_output}" >> $GITHUB_OUTPUT
+      - name: Bump and commit version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const allVersions = JSON.parse(process.env.VERSIONS).reverse();
+            // Filter only stable versions (exclude beta, alpha, rc, etc.)
+            const versions = allVersions.filter(v => !v.includes('-'));
+            if (versions.length === 0) {
+              throw Error("No stable versions found");
+            }
+            const currMajor = versions[0].split(".")[0];
+            const prevVersion = versions.find(v => !v.startsWith(`${currMajor}.`));
+            if (!prevVersion) {
+              throw Error("Previous major versions not found");
+            }
+            const versionParts = prevVersion.split(".");
+            if (versionParts.length !== 3) {
+              throw Error(`Cannot parse version ${prevVersion}`);
+            }
+            if (process.env.VERSION_TYPE === "minor") {
+              versionParts[1] = `${Number(versionParts[1])+1}`;
+              versionParts[2] = "0";
+            }
+            else {
+              versionParts[2] = `${Number(versionParts[2])+1}`;
+            }
+            const newVersion = versionParts.join(".");
+            core.info(`New version: ${newVersion}`);
+            try {
+              core.exportVariable('PUBLISH_VERSION', newVersion);
+              core.exportVariable('PUBLISH_VERSION_MAJOR', versionParts[0]);
+            } catch (error) {
+              core.setFailed(error.message);
+            }
+        env:
+          VERSION_TYPE: ${{ github.event.inputs.version_type }}
+          VERSIONS: ${{ steps.npm_versions.outputs.npm_versions }}
+      - name: Set version
+        run: |
+          npm version ${{ env.PUBLISH_VERSION }} --git-tag-version=false
+      - name: Publish version
+        run: npm publish --tag stable-v${{ env.PUBLISH_VERSION_MAJOR }} --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GRAVITY_UI_BOT_NPM_TOKEN }}
+        shell: bash
+      - name: Set latest dist-tag
+        if: ${{ inputs.set_latest }}
+        run: npm dist-tag add @gravity-ui/navigation@${{ env.PUBLISH_VERSION }} latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GRAVITY_UI_BOT_NPM_TOKEN }}
+        shell: bash
+      - name: Commit version and create tag
+        run: |
+          git config user.name "gravity-ui-bot"
+          git config user.email "gravity-ui-bot@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "chore(v${{ env.PUBLISH_VERSION_MAJOR }}): release ${{ env.PUBLISH_VERSION }}"
+          git tag "v${{ env.PUBLISH_VERSION }}"
+          git push origin HEAD --tags


### PR DESCRIPTION
## Summary
- add `set_latest` boolean input to `release-previous-stable.yml` in the `v4` branch
- keep previous-stable publish flow unchanged by default
- optionally assign the published version the npm `latest` dist-tag after publish
- reset patch to `0` on minor bumps so versioning becomes `major.minor.0`

## Testing
- npx prettier --check .github/workflows/release-previous-stable.yml