### PR TITLE
chore(ci): create GitHub release in previous stable workflow

### DIFF
--- a/.github/workflows/release-previous-stable.yml
+++ b/.github/workflows/release-previous-stable.yml
@@ -103,3 +103,19 @@ jobs:
           git commit -m "chore(v${{ env.PUBLISH_VERSION_MAJOR }}): release ${{ env.PUBLISH_VERSION }}"
           git tag "v${{ env.PUBLISH_VERSION }}"
           git push origin HEAD --tags
+      - name: Create GitHub release
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GRAVITY_UI_BOT_GITHUB_TOKEN }}
+          script: |
+            const tag = `v${process.env.PUBLISH_VERSION}`;
+
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              name: tag,
+              generate_release_notes: true,
+            });
+        env:
+          PUBLISH_VERSION: ${{ env.PUBLISH_VERSION }}


### PR DESCRIPTION
## Summary
- add GitHub Release creation to `release-previous-stable.yml` after pushing the version tag
- use GitHub REST API via `actions/github-script`, similar in approach to `release-please`

## Testing
- npx prettier --check .github/workflows/release-previous-stable.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated release process to automatically generate and publish release notes when new versions are tagged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->