### PR TITLE
chore(ci): sync previous stable latest tags in npm and github

### DIFF
--- a/.github/workflows/release-previous-stable.yml
+++ b/.github/workflows/release-previous-stable.yml
@@ -109,6 +109,7 @@ jobs:
           github-token: ${{ secrets.GRAVITY_UI_BOT_GITHUB_TOKEN }}
           script: |
             const tag = `v${process.env.PUBLISH_VERSION}`;
+            const makeLatest = process.env.SET_LATEST === 'true' ? 'true' : 'false';
 
             await github.rest.repos.createRelease({
               owner: context.repo.owner,
@@ -116,6 +117,8 @@ jobs:
               tag_name: tag,
               name: tag,
               generate_release_notes: true,
+              make_latest: makeLatest,
             });
         env:
           PUBLISH_VERSION: ${{ env.PUBLISH_VERSION }}
+          SET_LATEST: ${{ inputs.set_latest }}


### PR DESCRIPTION
## Summary
- branch from the latest `v4`
- sync GitHub `make_latest` with the existing `set_latest` workflow input
- keep npm `latest` and GitHub `Latest release` driven by the same flag for previous-stable releases

## Testing
- npx prettier --check .github/workflows/release-previous-stable.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation workflow to enable improved control over which releases are designated as "latest" on GitHub based on configurable workflow inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->