### PR TITLE
feat: migrate tooltip to popup in menu items

### DIFF
--- a/src/components/AsideHeader/components/CompositeBar/CompositeBar.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/CompositeBar.tsx
@@ -6,7 +6,8 @@ import AutoSizer, {Size} from 'react-virtualized-auto-sizer';
 import {createBlock} from '../../../utils/cn';
 import {AsideHeaderItem} from '../../types';
 
-import {Item, ItemProps} from './Item/Item';
+import {Item} from './Item/Item';
+import {ItemProps} from './Item/Item.types';
 import {COLLAPSE_ITEM_ID} from './constants';
 import {
     getAutosizeListItems,

--- a/src/components/AsideHeader/components/CompositeBar/Item/CollapsedPopup.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/Item/CollapsedPopup.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+
+import {Icon, List, Popup} from '@gravity-ui/uikit';
+
+import {MakeItemParams} from '../../../../types';
+import {createBlock} from '../../../../utils/cn';
+import {useAsideHeaderInnerContext} from '../../../AsideHeaderContext';
+import {POPUP_ITEM_HEIGHT, POPUP_PLACEMENT} from '../constants';
+import {getSelectedItemIndex} from '../utils';
+
+import type {ItemInnerProps} from './Item';
+import {renderItemTitle} from './renderItemTitle';
+
+import styles from './Item.module.scss';
+
+const b = createBlock('composite-bar-item', styles);
+
+export interface CollapsedPopupProps {
+    anchorRef: React.RefObject<HTMLElement>;
+    onOpenChange: () => void;
+}
+
+export function CollapsedPopup({
+    onItemClick,
+    collapseItems,
+    anchorRef,
+    onOpenChange,
+}: ItemInnerProps & CollapsedPopupProps) {
+    const {compact} = useAsideHeaderInnerContext();
+    return collapseItems?.length ? (
+        <Popup
+            strategy="fixed"
+            placement={POPUP_PLACEMENT}
+            open={true}
+            anchorElement={anchorRef.current}
+            onOpenChange={onOpenChange}
+        >
+            <div className={b('collapse-items-popup-content')}>
+                <List
+                    itemClassName={b('root-collapse-item')}
+                    items={collapseItems}
+                    selectedItemIndex={getSelectedItemIndex(collapseItems)}
+                    itemHeight={POPUP_ITEM_HEIGHT}
+                    itemsHeight={collapseItems.length * POPUP_ITEM_HEIGHT}
+                    virtualized={false}
+                    filterable={false}
+                    sortable={false}
+                    onItemClick={onOpenChange}
+                    renderItem={(item) => {
+                        const makeCollapseNode = ({
+                            title: titleEl,
+                            icon: iconEl,
+                        }: MakeItemParams) => {
+                            const [Tag, tagProps] = item.href
+                                ? ['a' as const, {href: item.href}]
+                                : ['button' as const, {}];
+
+                            return (
+                                <Tag
+                                    {...tagProps}
+                                    className={b('collapse-item')}
+                                    onClick={(event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+                                        onItemClick?.(item, true, event);
+                                    }}
+                                >
+                                    {iconEl}
+                                    {titleEl}
+                                </Tag>
+                            );
+                        };
+
+                        const titleNode = renderItemTitle(item);
+                        const iconNode = item.icon && (
+                            <Icon data={item.icon} size={14} className={b('collapse-item-icon')} />
+                        );
+
+                        const params = {title: titleNode, icon: iconNode};
+                        const opts = {
+                            compact: Boolean(compact),
+                            collapsed: true,
+                            item,
+                            ref: anchorRef,
+                        };
+                        if (typeof item.itemWrapper === 'function') {
+                            return item.itemWrapper(params, makeCollapseNode, opts);
+                        } else {
+                            return makeCollapseNode(params);
+                        }
+                    }}
+                />
+            </div>
+        </Popup>
+    ) : null;
+}
+
+CollapsedPopup.displayName = 'CollapsedPopup';

--- a/src/components/AsideHeader/components/CompositeBar/Item/CollapsedPopup.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/Item/CollapsedPopup.tsx
@@ -8,7 +8,7 @@ import {useAsideHeaderInnerContext} from '../../../AsideHeaderContext';
 import {POPUP_ITEM_HEIGHT, POPUP_PLACEMENT} from '../constants';
 import {getSelectedItemIndex} from '../utils';
 
-import type {ItemInnerProps} from './Item';
+import type {ItemInnerProps} from './Item.types';
 import {renderItemTitle} from './renderItemTitle';
 
 import styles from './Item.module.scss';

--- a/src/components/AsideHeader/components/CompositeBar/Item/Item.module.scss
+++ b/src/components/AsideHeader/components/CompositeBar/Item/Item.module.scss
@@ -10,6 +10,7 @@ $actionLeftRightMargin: 10px;
 
     $class: &;
     --gn-composite-bar-item-action-size: 36px;
+    --gn-aside-header-item-expanded-radius: #{variables.$item-expanded-radius};
 
     --_--horizontal-divider-line-color: var(--g-color-line-generic);
 
@@ -228,6 +229,43 @@ $actionLeftRightMargin: 10px;
 
     &__icon-tooltip_item-type_action {
         margin-left: 10px;
+    }
+
+    &__icon-popover {
+        display: flex;
+        box-sizing: border-box;
+        padding: var(--g-spacing-1) var(--g-spacing-2);
+        align-items: center;
+        border-radius: 12px;
+    }
+
+    &__icon-popover_item-type_action {
+        margin-left: 10px;
+    }
+
+    &__compact-popover-content {
+        box-sizing: border-box;
+        min-width: var(--gn-aside-header-size, 240px);
+        border-radius: var(--gn-aside-header-item-expanded-radius);
+    }
+
+    &__compact-popover-item {
+        box-sizing: border-box;
+        height: #{variables.$item-height};
+
+        &#{$class}_type_regular {
+            border-radius: var(--gn-aside-header-item-expanded-radius);
+        }
+    }
+
+    &_hide-icon {
+        #{$class}__icon-place {
+            display: none;
+        }
+
+        #{$class}__title {
+            margin-left: var(--g-spacing-4);
+        }
     }
 
     &:not(&_compact) {

--- a/src/components/AsideHeader/components/CompositeBar/Item/Item.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/Item/Item.tsx
@@ -47,6 +47,7 @@ export const Item: React.FC<ItemInnerProps> = (props) => {
     } = props;
 
     const [open, toggleOpen] = React.useState<boolean>(false);
+    const [compactNavPopoverOpen, setCompactNavPopoverOpen] = React.useState(false);
 
     const ref = React.useRef<HTMLAnchorElement & HTMLButtonElement>(null);
     const anchorRef = anchoreRefProp?.current ? anchoreRefProp : ref;
@@ -68,6 +69,9 @@ export const Item: React.FC<ItemInnerProps> = (props) => {
                 ref.current?.contains(event.target as Node)
             ) {
                 return;
+            }
+            if (newOpen) {
+                setCompactNavPopoverOpen(false);
             }
             onOpenChangePopup?.(newOpen, event, reason);
         },
@@ -112,6 +116,14 @@ export const Item: React.FC<ItemInnerProps> = (props) => {
         return (
             <Popover
                 disabled={compactPopoverDisabled}
+                open={compactNavPopoverOpen}
+                onOpenChange={(nextOpen) => {
+                    if (nextOpen && compactPopoverDisabled) {
+                        return;
+                    }
+
+                    setCompactNavPopoverOpen(nextOpen);
+                }}
                 placement="right"
                 strategy="fixed"
                 offset={defaultPopupOffset}
@@ -134,6 +146,10 @@ export const Item: React.FC<ItemInnerProps> = (props) => {
                             renderPopupContent={undefined}
                             onOpenChangePopup={undefined}
                             popupRef={undefined}
+                            onItemClick={(item, collapsed, event) => {
+                                setCompactNavPopoverOpen(false);
+                                onItemClick?.(item, collapsed, event);
+                            }}
                         />
                     </div>
                 }
@@ -157,6 +173,10 @@ export const Item: React.FC<ItemInnerProps> = (props) => {
                     onClick={(event: React.MouseEvent<HTMLElement, MouseEvent>) => {
                         if (stopClickPropagation) {
                             event.stopPropagation();
+                        }
+
+                        if (compact) {
+                            setCompactNavPopoverOpen(false);
                         }
 
                         if (collapsedItem) {

--- a/src/components/AsideHeader/components/CompositeBar/Item/Item.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/Item/Item.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import {ActionTooltip, Icon, Popup, PopupPlacement, PopupProps} from '@gravity-ui/uikit';
-
-import {AsideHeaderItem} from 'src/components/AsideHeader/types';
+import {ActionTooltip, Icon, Popover, Popup, PopupPlacement, PopupProps} from '@gravity-ui/uikit';
 
 import {ASIDE_HEADER_ICON_SIZE} from '../../../../constants';
 import {MakeItemParams} from '../../../../types';
@@ -12,28 +10,14 @@ import {COLLAPSE_ITEM_ID, ITEM_TYPE_REGULAR} from '../constants';
 
 import {CollapsedPopup} from './CollapsedPopup';
 import {ItemInnerProps, ItemProps} from './Item.types';
+import {renderItemTitle} from './renderItemTitle';
 
 import styles from './Item.module.scss';
 
 const b = createBlock('composite-bar-item', styles);
 
-function renderItemTitle(params: Pick<AsideHeaderItem, 'title' | 'rightAdornment'>) {
-    let titleNode = <div className={b('title-text')}>{params.title}</div>;
-
-    if (params.rightAdornment) {
-        titleNode = (
-            <React.Fragment>
-                {titleNode}
-                <div className={b('title-adornment')}>{params.rightAdornment}</div>
-            </React.Fragment>
-        );
-    }
-
-    return titleNode;
-}
-
 const defaultPopupPlacement: PopupPlacement = ['right-end'];
-const defaultPopupOffset: NonNullable<PopupProps['offset']> = {mainAxis: 8, crossAxis: -20};
+const defaultPopupOffset: NonNullable<PopupProps['offset']> = {mainAxis: 14};
 
 export const Item: React.FC<ItemInnerProps> = (props) => {
     const {
@@ -58,6 +42,8 @@ export const Item: React.FC<ItemInnerProps> = (props) => {
         title,
         href,
         qa,
+        hideIcon = false,
+        stopClickPropagation = false,
     } = props;
 
     const [open, toggleOpen] = React.useState<boolean>(false);
@@ -92,25 +78,68 @@ export const Item: React.FC<ItemInnerProps> = (props) => {
         return <div className={b('menu-divider')} />;
     }
 
+    const compactPopoverDisabled = !enableTooltip || (collapsedItem && open) || popupVisible;
+
     const makeIconNode = (iconEl: React.ReactNode): React.ReactNode => {
-        return compact ? (
-            <ActionTooltip
-                title=""
-                description={tooltipText}
-                disabled={!enableTooltip || (collapsedItem && open) || popupVisible}
-                placement="right"
-                className={b('icon-tooltip', {'item-type': type})}
+        if (!compact) {
+            return iconEl;
+        }
+
+        const iconButton = (
+            <div
+                onMouseEnter={() => onMouseEnter?.()}
+                onMouseLeave={() => onMouseLeave?.()}
+                className={b('btn-icon')}
             >
-                <div
-                    onMouseEnter={() => onMouseEnter?.()}
-                    onMouseLeave={() => onMouseLeave?.()}
-                    className={b('btn-icon')}
+                {iconEl}
+            </div>
+        );
+
+        if (collapsedItem) {
+            return (
+                <ActionTooltip
+                    title=""
+                    description={tooltipText}
+                    disabled={compactPopoverDisabled}
+                    placement="right"
+                    className={b('icon-tooltip', {'item-type': type})}
                 >
-                    {iconEl}
-                </div>
-            </ActionTooltip>
-        ) : (
-            iconEl
+                    {iconButton}
+                </ActionTooltip>
+            );
+        }
+
+        return (
+            <Popover
+                disabled={compactPopoverDisabled}
+                placement="right"
+                strategy="fixed"
+                offset={defaultPopupOffset}
+                enableSafePolygon
+                openDelay={100}
+                closeDelay={100}
+                className={b('icon-popover', {'item-type': type})}
+                content={
+                    <div className={b('compact-popover-content')}>
+                        <Item
+                            {...props}
+                            qa={undefined}
+                            compact={false}
+                            className={b('compact-popover-item', props.className)}
+                            hideIcon
+                            stopClickPropagation
+                            enableTooltip={false}
+                            bringForward={false}
+                            popupVisible={false}
+                            renderPopupContent={undefined}
+                            onOpenChangePopup={undefined}
+                            popupRef={undefined}
+                        />
+                    </div>
+                }
+            >
+                {iconButton}
+            </Popover>
         );
     };
 
@@ -121,11 +150,15 @@ export const Item: React.FC<ItemInnerProps> = (props) => {
             <React.Fragment>
                 <Tag
                     {...tagProps}
-                    className={b({type, current, compact}, className)}
+                    className={b({type, current, compact, 'hide-icon': hideIcon}, className)}
                     ref={ref}
                     data-type={type}
                     data-qa={qa}
                     onClick={(event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+                        if (stopClickPropagation) {
+                            event.stopPropagation();
+                        }
+
                         if (collapsedItem) {
                             /**
                              * This is the "more" button (three dots) that shows additional menu items in a popup.
@@ -179,9 +212,10 @@ export const Item: React.FC<ItemInnerProps> = (props) => {
         return createdNode;
     };
 
-    const iconNode = icon ? (
-        <Icon qa={iconQa} data={icon} size={iconSize} className={b('icon')} />
-    ) : null;
+    const iconNode =
+        hideIcon || !icon ? null : (
+            <Icon qa={iconQa} data={icon} size={iconSize} className={b('icon')} />
+        );
     const titleNode = renderItemTitle({title, rightAdornment});
     const params = {icon: iconNode, title: titleNode};
     let highlightedNode = null;

--- a/src/components/AsideHeader/components/CompositeBar/Item/Item.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/Item/Item.tsx
@@ -1,34 +1,21 @@
 import React from 'react';
 
-import {ActionTooltip, Icon, List, Popup, PopupPlacement, PopupProps} from '@gravity-ui/uikit';
+import {ActionTooltip, Icon, Popup, PopupPlacement, PopupProps} from '@gravity-ui/uikit';
 
 import {AsideHeaderItem} from 'src/components/AsideHeader/types';
 
 import {ASIDE_HEADER_ICON_SIZE} from '../../../../constants';
 import {MakeItemParams} from '../../../../types';
 import {createBlock} from '../../../../utils/cn';
-import {useAsideHeaderInnerContext} from '../../../AsideHeaderContext';
 import {HighlightedItem} from '../HighlightedItem/HighlightedItem';
-import {
-    COLLAPSE_ITEM_ID,
-    ITEM_TYPE_REGULAR,
-    POPUP_ITEM_HEIGHT,
-    POPUP_PLACEMENT,
-} from '../constants';
-import {getSelectedItemIndex} from '../utils';
+import {COLLAPSE_ITEM_ID, ITEM_TYPE_REGULAR} from '../constants';
+
+import {CollapsedPopup} from './CollapsedPopup';
+import {ItemInnerProps, ItemProps} from './Item.types';
 
 import styles from './Item.module.scss';
 
 const b = createBlock('composite-bar-item', styles);
-
-export interface ItemProps extends AsideHeaderItem {}
-
-interface ItemInnerProps extends ItemProps {
-    className?: string;
-    collapseItems?: AsideHeaderItem[];
-    onMouseEnter?: () => void;
-    onMouseLeave?: () => void;
-}
 
 function renderItemTitle(params: Pick<AsideHeaderItem, 'title' | 'rightAdornment'>) {
     let titleNode = <div className={b('title-text')}>{params.title}</div>;
@@ -241,81 +228,3 @@ export const Item: React.FC<ItemInnerProps> = (props) => {
 };
 
 Item.displayName = 'Item';
-
-interface CollapsedPopupProps {
-    anchorRef: React.RefObject<HTMLElement>;
-    onOpenChange: () => void;
-}
-
-function CollapsedPopup({
-    onItemClick,
-    collapseItems,
-    anchorRef,
-    onOpenChange,
-}: ItemInnerProps & CollapsedPopupProps) {
-    const {compact} = useAsideHeaderInnerContext();
-    return collapseItems?.length ? (
-        <Popup
-            strategy="fixed"
-            placement={POPUP_PLACEMENT}
-            open={true}
-            anchorElement={anchorRef.current}
-            onOpenChange={onOpenChange}
-        >
-            <div className={b('collapse-items-popup-content')}>
-                <List
-                    itemClassName={b('root-collapse-item')}
-                    items={collapseItems}
-                    selectedItemIndex={getSelectedItemIndex(collapseItems)}
-                    itemHeight={POPUP_ITEM_HEIGHT}
-                    itemsHeight={collapseItems.length * POPUP_ITEM_HEIGHT}
-                    virtualized={false}
-                    filterable={false}
-                    sortable={false}
-                    onItemClick={onOpenChange}
-                    renderItem={(item) => {
-                        const makeCollapseNode = ({
-                            title: titleEl,
-                            icon: iconEl,
-                        }: MakeItemParams) => {
-                            const [Tag, tagProps] = item.href
-                                ? ['a' as const, {href: item.href}]
-                                : ['button' as const, {}];
-
-                            return (
-                                <Tag
-                                    {...tagProps}
-                                    className={b('collapse-item')}
-                                    onClick={(event: React.MouseEvent<HTMLElement, MouseEvent>) => {
-                                        onItemClick?.(item, true, event);
-                                    }}
-                                >
-                                    {iconEl}
-                                    {titleEl}
-                                </Tag>
-                            );
-                        };
-
-                        const titleNode = renderItemTitle(item);
-                        const iconNode = item.icon && (
-                            <Icon data={item.icon} size={14} className={b('collapse-item-icon')} />
-                        );
-
-                        const params = {title: titleNode, icon: iconNode};
-                        const opts = {
-                            compact: Boolean(compact),
-                            collapsed: true,
-                            item,
-                            ref: anchorRef,
-                        };
-                        if (typeof item.itemWrapper === 'function') {
-                            return item.itemWrapper(params, makeCollapseNode, opts);
-                        } else {
-                            return makeCollapseNode(params);
-                        }
-                    }}
-                />
-            </div>
-        </Popup>
-    ) : null;
-}

--- a/src/components/AsideHeader/components/CompositeBar/Item/Item.types.ts
+++ b/src/components/AsideHeader/components/CompositeBar/Item/Item.types.ts
@@ -7,4 +7,11 @@ export interface ItemInnerProps extends ItemProps {
     collapseItems?: AsideHeaderItem[];
     onMouseEnter?: () => void;
     onMouseLeave?: () => void;
+    /** When true, the icon slot is not rendered (e.g. compact popover: icon stays in the bar). */
+    hideIcon?: boolean;
+    /**
+     * Stops click bubbling so portaled content (e.g. compact popover duplicate) does not trigger
+     * the parent Item's onClick in the React tree.
+     */
+    stopClickPropagation?: boolean;
 }

--- a/src/components/AsideHeader/components/CompositeBar/Item/Item.types.ts
+++ b/src/components/AsideHeader/components/CompositeBar/Item/Item.types.ts
@@ -1,0 +1,10 @@
+import {AsideHeaderItem} from 'src/components/AsideHeader/types';
+
+export interface ItemProps extends AsideHeaderItem {}
+
+export interface ItemInnerProps extends ItemProps {
+    className?: string;
+    collapseItems?: AsideHeaderItem[];
+    onMouseEnter?: () => void;
+    onMouseLeave?: () => void;
+}

--- a/src/components/AsideHeader/components/CompositeBar/Item/renderItemTitle.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/Item/renderItemTitle.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import {AsideHeaderItem} from 'src/components/AsideHeader/types';
+
+import {createBlock} from '../../../../utils/cn';
+
+import styles from './Item.module.scss';
+
+const b = createBlock('composite-bar-item', styles);
+
+export function renderItemTitle(params: Pick<AsideHeaderItem, 'title' | 'rightAdornment'>) {
+    let titleNode = <div className={b('title-text')}>{params.title}</div>;
+
+    if (params.rightAdornment) {
+        titleNode = (
+            <React.Fragment>
+                {titleNode}
+                <div className={b('title-adornment')}>{params.rightAdornment}</div>
+            </React.Fragment>
+        );
+    }
+
+    return titleNode;
+}


### PR DESCRIPTION
- Moved to another file CollapsedPopup component
- Use Popover instead of ActionTooltip for Items in compact mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added popup functionality to display collapsed navigation items with interactive list support
  * Enhanced compact mode with popover-based icon interactions for improved usability

* **Styling**
  * Added new CSS classes and styling variables for popover and compact navigation displays
  * Improved visual presentation of navigation elements in collapsed states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->