### PR TITLE
fix(AsideHeader): close AllPagesPanel on menu item click

### DIFF
--- a/src/components/AsideHeader/components/AllPagesPanel/AllPagesPanel.tsx
+++ b/src/components/AsideHeader/components/AllPagesPanel/AllPagesPanel.tsx
@@ -24,7 +24,7 @@ interface AllPagesPanelProps {
 
 export const AllPagesPanel: React.FC<AllPagesPanelProps> = (props) => {
     const {startEditIcon, onEditModeChanged, className} = props;
-    const {menuItems, defaultMenuItems, onMenuItemsChanged, editMenuProps} =
+    const {menuItems, defaultMenuItems, onMenuItemsChanged, editMenuProps, onClosePanel} =
         useAsideHeaderInnerContext();
 
     const menuItemsRef = useRef(menuItems);
@@ -52,8 +52,9 @@ export const AllPagesPanel: React.FC<AllPagesPanelProps> = (props) => {
         (item, _index, _forwardKey, event) => {
             // TODO: make event an optional argument
             item.onItemClick?.(item, false, event as React.MouseEvent<HTMLElement, MouseEvent>);
+            onClosePanel?.();
         },
-        [],
+        [onClosePanel],
     );
 
     const togglePageVisibility = useCallback(

--- a/src/components/AsideHeader/components/AllPagesPanel/__tests__/AllPagesPanel.test.tsx
+++ b/src/components/AsideHeader/components/AllPagesPanel/__tests__/AllPagesPanel.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+
+import {Gear} from '@gravity-ui/icons';
+import {ThemeProvider} from '@gravity-ui/uikit';
+import {fireEvent, render, screen} from '@testing-library/react';
+
+import {AsideHeaderInnerContextProvider} from '../../../AsideHeaderContext';
+import {AsideHeaderItem} from '../../../types';
+import {AllPagesPanel} from '../AllPagesPanel';
+
+jest.mock('../i18n', () => ({
+    __esModule: true,
+    default: (key: string) => key,
+}));
+
+function renderAllPagesPanel(props: {menuItems: AsideHeaderItem[]; onClosePanel: jest.Mock}) {
+    const contextValue = {
+        compact: false,
+        size: 200,
+        menuItems: props.menuItems,
+        allPagesIsAvailable: true,
+        onItemClick: () => {},
+        onClosePanel: props.onClosePanel,
+    } as any;
+
+    return render(
+        <ThemeProvider theme="light">
+            <AsideHeaderInnerContextProvider value={contextValue}>
+                <AllPagesPanel />
+            </AsideHeaderInnerContextProvider>
+        </ThemeProvider>,
+    );
+}
+
+describe('AllPagesPanel', () => {
+    it('should call item.onItemClick and close the panel on item click', () => {
+        const onClosePanel = jest.fn();
+        const dashboardOnItemClick = jest.fn();
+
+        const menuItems: AsideHeaderItem[] = [
+            {id: 'dashboard', title: 'Dashboard', icon: Gear, onItemClick: dashboardOnItemClick},
+        ];
+
+        renderAllPagesPanel({menuItems, onClosePanel});
+
+        fireEvent.click(screen.getByText('Dashboard'));
+
+        expect(dashboardOnItemClick).toHaveBeenCalledTimes(1);
+        expect(onClosePanel).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
Clicking a menu item inside AllPagesPanel now closes the panel, matching the behavior of the main sidebar menu. Edit mode is unaffected since item clicks are suppressed there.