### PR TITLE
feat(SettingsMenu): add aria attributes

### DIFF
--- a/src/components/AsideHeader/components/CompositeBar/Item/Item.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/Item/Item.tsx
@@ -85,6 +85,7 @@ export const Item: React.FC<ItemInnerProps> = (props) => {
         setCollapseBlocker,
         hidden,
         preventUserRemoving,
+        menuItemAriaProps,
     } = props;
 
     const ref = React.useRef<HTMLAnchorElement & HTMLButtonElement>(null);
@@ -153,11 +154,12 @@ export const Item: React.FC<ItemInnerProps> = (props) => {
             <React.Fragment>
                 <Tag
                     {...tagProps}
+                    {...(menuItemAriaProps ?? {})}
                     className={b({type, current, collapsed: !isExpanded}, className)}
                     ref={ref}
                     data-qa={qa}
                     data-type={type}
-                    aria-label={ariaLabel}
+                    aria-label={menuItemAriaProps?.['aria-label'] ?? ariaLabel}
                     onClick={(event: React.MouseEvent<HTMLElement, MouseEvent>) => {
                         onItemClick?.(props, false, event, {setCollapseBlocker});
                     }}

--- a/src/components/Settings/SettingsMenu/SettingsMenu.tsx
+++ b/src/components/Settings/SettingsMenu/SettingsMenu.tsx
@@ -91,6 +91,7 @@ function renderMenuItem(
     return (
         <span
             key={item.title}
+            {...item.menuItemAriaProps}
             className={b('item', {
                 selected: activeItemId === item.id,
                 disabled: item.disabled,

--- a/src/components/Settings/collect-settings.ts
+++ b/src/components/Settings/collect-settings.ts
@@ -5,6 +5,7 @@ import {IconProps} from '@gravity-ui/uikit';
 import {SettingsSelection} from './Selection/types';
 import {getSettingsDescriptionWithAllResultsPage} from './SettingsSearch/AllResultsPage';
 import {escapeStringForRegExp, invariant} from './helpers';
+import type {SettingsMenuItemAriaProps} from './types';
 
 export type SettingsMenu = (SettingsMenuGroup | SettingsMenuItem)[];
 
@@ -19,6 +20,7 @@ export interface SettingsMenuItem {
     icon?: IconProps;
     withBadge?: boolean;
     disabled?: boolean;
+    menuItemAriaProps?: SettingsMenuItemAriaProps;
 }
 
 export interface SettingsPage {
@@ -149,6 +151,7 @@ function getSettingsFromChildrenRecursive(
                     icon: element.props.icon,
                     withBadge: pages[pageId].withBadge,
                     disabled: pages[pageId].hidden,
+                    menuItemAriaProps: element.props.menuItemAriaProps,
                 });
             }
         }

--- a/src/components/Settings/index.ts
+++ b/src/components/Settings/index.ts
@@ -9,4 +9,5 @@ export type {
     SettingsPageProps,
     SettingsSectionProps,
     SettingsItemProps,
+    SettingsMenuItemAriaProps,
 } from './types';

--- a/src/components/Settings/types.ts
+++ b/src/components/Settings/types.ts
@@ -10,12 +10,16 @@ interface GroupItem {
     items: Item[];
 }
 
+export type SettingsMenuItemAriaProps = React.AriaAttributes &
+    Pick<React.HTMLAttributes<HTMLSpanElement>, 'role'>;
+
 export interface Item {
     id: string;
     title: string;
     icon?: IconProps;
     disabled?: boolean;
     withBadge?: boolean;
+    menuItemAriaProps?: SettingsMenuItemAriaProps;
 }
 
 type SettingsMenuItems = (GroupItem | Item)[];
@@ -63,6 +67,8 @@ export interface SettingsPageProps {
     title?: string;
     icon?: IconProps;
     children: React.ReactNode;
+    /** Merged onto the left menu row in desktop Settings (`SettingsMenu`). */
+    menuItemAriaProps?: SettingsMenuItemAriaProps;
 }
 
 export interface SettingsSectionProps {

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -6,6 +6,9 @@ import {SetCollapseBlocker} from './AsideHeader/types';
 
 export type MenuItemType = 'regular' | 'action' | 'divider';
 
+export type AsideHeaderMenuItemAriaProps = React.AriaAttributes &
+    Pick<React.HTMLAttributes<HTMLButtonElement>, 'role'>;
+
 export type OpenModalSubscriber = (open: boolean) => void;
 
 export interface MakeItemParams {
@@ -52,6 +55,7 @@ export interface MenuItem extends QAProps {
      */
     groupId?: string;
     className?: string;
+    menuItemAriaProps?: AsideHeaderMenuItemAriaProps;
 }
 
 export interface MenuGroup {


### PR DESCRIPTION
Currently, SettingsMenu doesn't allow you to set Aria attributes, which prevents the interface from being accessible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Menu item components and settings menu now consistently accept and forward custom ARIA attributes to rendered menu elements.
  * Shared type definitions updated to expose structured ARIA-props types for aside/header and settings menu items, enabling richer accessibility metadata across menus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->