### PR TITLE
test: fix flaky "Axe is already running" in storybook a11y check

### DIFF
--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -7,12 +7,17 @@ import {checkA11y, configureAxe, injectAxe} from 'axe-playwright';
  * to learn more about the test-runner hooks API.
  */
 const config: TestRunnerConfig = {
-    async preVisit(page) {
-        await injectAxe(page);
-    },
     async postVisit(page, context) {
         // Get the entire context of a story, including parameters, args, argTypes, etc.
         const storyContext = await getStoryContext(page, context);
+
+        // Wait until the page is fully ready — including any navigation a story may
+        // trigger — then inject a fresh axe instance. A story-triggered navigation
+        // could leave the previously injected axe mid-run, making the next
+        // checkA11y fail with "Axe is already running"; the previous fixed delay
+        // mitigated this only flakily.
+        await waitForPageReady(page);
+        await injectAxe(page);
 
         // Apply story-level a11y rules
         await configureAxe(page, {
@@ -20,8 +25,6 @@ const config: TestRunnerConfig = {
             reporter: 'no-passes',
         });
 
-        // hack for prevent error "Axe is already running"
-        await new Promise((resolve) => setTimeout(resolve, 1000));
         await checkA11y(page, '#storybook-root', {
             verbose: false,
             detailedReport: true,


### PR DESCRIPTION
## Problem

The storybook test-runner a11y check (`.storybook/test-runner.ts`) intermittently fails with:

```
page.evaluate: Error: Axe is already running. Use `await axe.run()` to wait for the previous run to finish before starting a new run.
```

It surfaced on `components/ActionBar` (CI log):

```
An error occurred in the following story, most likely because of a navigation:
"components/ActionBar/Single Section". Retrying...
...
components/ActionBar › Showcase › smoke-test
  page.evaluate: Error: Axe is already running.
```

Some stories trigger a navigation (e.g. the anchors `href="/"` / `href="#"` in the ActionBar showcases). When that happens, the axe instance injected in `preVisit` can be left mid-run; the next story's `checkA11y` then throws "Axe is already running". The existing `setTimeout(1000)` workaround only mitigated this flakily.

## Fix

- Wait for the page to be fully ready with `waitForPageReady` — which was already imported but **never used** — instead of an arbitrary delay.
- Inject a **fresh** axe instance in `postVisit` (after the page settled) rather than in `preVisit`, so each a11y check runs against a clean axe instance even after a story navigation.
- Drop the now-unnecessary `preVisit` hook and the `setTimeout(1000)` hack.

## Notes

This is a test-infrastructure flake unrelated to component behavior; no source or public API changes. Full validation happens in CI (storybook build + `test-storybook`), since the race is timing-dependent and not reliably reproducible locally.
