### PR TITLE
fix(AllPagesPanel): set auto size

### DIFF
--- a/src/components/AsideHeader/useAsideHeaderInnerContextValue.tsx
+++ b/src/components/AsideHeader/useAsideHeaderInnerContextValue.tsx
@@ -73,6 +73,7 @@ export const useAsideHeaderInnerContextValue = (
                 id: InnerPanels.AllPages,
                 children: <AllPagesPanel />,
                 open: innerVisiblePanel === InnerPanels.AllPages,
+                size: 'auto',
             },
         ];
     }, [allPagesIsAvailable, panelItems, innerVisiblePanel]);


### PR DESCRIPTION
Cherry-pick of 903fcdf (#630) from `v4` into `v6`.

Sets `size: 'auto'` for the AllPages inner panel in `useAsideHeaderInnerContextValue`. Applied cleanly with no conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "All Pages" panel in the aside header to display with proper sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->