### PR TITLE
Treat runtime dependencies as external in rollup build to avoid duplicated modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "commander": "^11.0.0",
         "jscodeshift": "^0.15.0",
+        "lodash": "^4.17.21",
+        "react-virtualized-auto-sizer": "^1.0.20",
         "tslib": "^2.8.1"
       },
       "bin": {
@@ -24158,8 +24160,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -24256,7 +24257,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -26884,7 +26884,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -26951,7 +26950,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -27020,7 +27018,6 @@
       "version": "1.0.26",
       "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
       "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -28179,7 +28176,6 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
   "dependencies": {
     "commander": "^11.0.0",
     "jscodeshift": "^0.15.0",
-    "tslib": "^2.8.1"
+    "tslib": "^2.8.1",
+    "lodash": "^4.17.21",
+    "react-virtualized-auto-sizer": "^1.0.20"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -21,19 +21,20 @@ const cssAliases = {
     'AsideHeader/components/PageLayout/AsideFallback.js': 'AsideHeader',
 };
 
-// External dependency checker - shared between ESM and CJS builds
-const peerDeps = [
+// External dependency checker - shared between ESM and CJS builds.
+const externalPackages = [
     'react',
     'react-dom',
     '@bem-react/classname',
-    '@gravity-ui/components',
     '@gravity-ui/icons',
     '@gravity-ui/uikit',
+    'tslib',
+    'lodash',
+    'react-virtualized-auto-sizer',
 ];
 
 const isExternal = (id) => {
-    // Mark peer dependencies as external
-    return peerDeps.some((dep) => id.startsWith(dep));
+    return externalPackages.some((dep) => id === dep || id.startsWith(`${dep}/`));
 };
 
 // Single input file - Rollup will automatically detect and split components


### PR DESCRIPTION
## Summary

This PR changes the package build so runtime dependencies are treated as external during Rollup bundling.

## What changed

### Added runtime dependencies to `dependencies`

Packages such as `lodash` and `react-virtualized-auto-sizer` are imported by the library at runtime, so they need to be declared explicitly in `dependencies`.

### Updated Rollup externalization

The Rollup config now externalizes both:

* `dependencies`
* `peerDependencies`

This prevents Rollup from inlining runtime packages into `build/esm/node_modules` and `build/cjs/node_modules`.

### Removed redundant `peerDepsExternal()`

The build already uses an explicit `external` function, so `peerDepsExternal()` was redundant once runtime dependencies were included in the same externalization logic. Removing it keeps the config simpler and makes the behavior easier to reason about.

## Why this is needed

Before this change, Rollup could bundle runtime dependencies into the published output, which caused duplicate package instances in consumer applications. This was verified with Statoscope in a consumer project.

Reference report:

https://github.com/Lugertr/statoscope/tree/master/statoscope-reports

## Verification

The fix was validated by building the package locally, installing the produced tarball into a consumer project, and confirming that duplicate instances no longer appear in Statoscope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Hotkeys panel with additional configuration options for drawer behavior and navigation offset control.
  * All Pages panel now automatically closes after item selection.

* **Bug Fixes**
  * Fixed navigation panel positioning alignment.

* **Tests**
  * Added comprehensive test coverage for panel components.

* **Documentation**
  * Updated Hotkeys panel documentation with new configuration options.

* **Chores**
  * Updated build and CI workflows for improved maintainability.
  * Enhanced Jest testing infrastructure with style mocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->