### PR TITLE
feat: port main-only runtime changes to v6

### DIFF
--- a/codemods/transforms/unifyInterfaces.ts
+++ b/codemods/transforms/unifyInterfaces.ts
@@ -129,6 +129,7 @@ function updateImports(root: Collection, j: JSCodeshift): boolean {
             });
 
             if (hasBeenModified) {
+                // eslint-disable-next-line no-param-reassign
                 path.node.specifiers = newSpecifiers;
                 hasChanges = true;
             }

--- a/src/components/AsideHeader/components/CompositeBar/Item/Item.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/Item/Item.tsx
@@ -53,6 +53,7 @@ export const Item: React.FC<ItemInnerProps> = (props) => {
         hideIcon = false,
         stopClickPropagation = false,
         menuGroupNestedTreeConnector,
+        menuItemAriaProps,
     } = props;
 
     const [compactNavPopoverOpen, setCompactNavPopoverOpen] = React.useState(false);
@@ -160,6 +161,7 @@ export const Item: React.FC<ItemInnerProps> = (props) => {
     const makeNode = ({icon: iconEl, title: titleEl}: MakeItemParams) => {
         const wrappedByItemWrapper = typeof itemWrapper === 'function';
         const rowClassName = b({type, current, compact, 'hide-icon': hideIcon}, className);
+        const ariaLabel = typeof title === 'string' ? title : undefined;
 
         const handleRowClick = (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
             if (compact && !collapsedItem && !showMenuPopup && !current) {
@@ -205,9 +207,11 @@ export const Item: React.FC<ItemInnerProps> = (props) => {
         );
 
         const rowEventProps = {
+            ...(menuItemAriaProps ?? {}),
             className: rowClassName,
             'data-type': type,
             'data-qa': qa,
+            'aria-label': menuItemAriaProps?.['aria-label'] ?? ariaLabel,
             onClick: handleRowClick,
             onClickCapture: onItemClickCapture,
             onMouseEnter: () => {
@@ -232,7 +236,11 @@ export const Item: React.FC<ItemInnerProps> = (props) => {
             );
         } else if (wrappedByItemWrapper) {
             tagNode = (
-                <div {...rowEventProps} role="button" ref={ref as React.RefObject<HTMLDivElement>}>
+                <div
+                    {...rowEventProps}
+                    role={menuItemAriaProps?.role ?? 'button'}
+                    ref={ref as React.RefObject<HTMLDivElement>}
+                >
                     {rowChildren}
                 </div>
             );

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
+import React, {PropsWithChildren} from 'react';
 
-import {Flex, Loader} from '@gravity-ui/uikit';
+import {Flex, Loader, TabPanel, TabProvider} from '@gravity-ui/uikit';
 import identity from 'lodash/identity';
 
 import {Title} from '../Title';
 
 import {
     SettingsSelectionContextProvider,
+    SettingsSelectionProviderContextValue,
     useSettingsSelectionContext,
     useSettingsSelectionProviderValue,
 } from './Selection/context';
@@ -18,7 +19,7 @@ import {SettingsPageComponent} from './SettingsPage/SettingsPageComponent';
 import {useAllResultsPage} from './SettingsSearch/AllResultsPage';
 import {SettingsSearch} from './SettingsSearch/SettingsSearch';
 import {b} from './b';
-import {getSettingsFromChildren} from './collect-settings';
+import {SettingsMenu as SettingsMenuType, getSettingsFromChildren} from './collect-settings';
 import i18n from './i18n';
 import type {
     SettingsContentProps,
@@ -62,6 +63,116 @@ export function Settings({
     );
 }
 
+interface SettingsContentInnerProps
+    extends PropsWithChildren,
+        Pick<SettingsContentProps, 'initialSearch' | 'selection' | 'title' | 'filterPlaceholder'> {
+    initialSearch?: string;
+    selected: SettingsSelectionProviderContextValue;
+    activePage?: string;
+    menu: SettingsMenuType;
+    search: string;
+    setSearch: (newValue: string) => void;
+    onPageChange: (newPage: string | undefined) => void;
+}
+
+function SettingsContentInnerMobile({
+    initialSearch,
+    selection,
+    menu,
+    activePage,
+    setSearch,
+    onPageChange,
+    children,
+}: SettingsContentInnerProps) {
+    const searchInputRef = React.useRef<HTMLInputElement>(null);
+
+    return (
+        <TabProvider value={activePage} onUpdate={onPageChange}>
+            <React.Fragment>
+                <SettingsSearch
+                    inputRef={searchInputRef}
+                    className={b('search')}
+                    initialValue={initialSearch}
+                    selection={selection}
+                    onChange={setSearch}
+                    autoFocus={false}
+                    inputSize={'xl'}
+                />
+                <SettingsMenuMobile items={menu} className={b('tabs')} />
+            </React.Fragment>
+            {activePage ? <TabPanel value={activePage}>{children}</TabPanel> : children}
+        </TabProvider>
+    );
+}
+
+function SettingsContentInnerDesktop({
+    title,
+    selection,
+    menu,
+    activePage,
+    filterPlaceholder,
+    initialSearch,
+    search,
+    setSearch,
+    onPageChange,
+    children,
+}: SettingsContentInnerProps) {
+    const menuRef = React.useRef<SettingsMenuInstance>(null);
+    const searchInputRef = React.useRef<HTMLInputElement>(null);
+
+    React.useEffect(() => {
+        menuRef.current?.clearFocus();
+    }, [search]);
+
+    React.useEffect(() => {
+        const handler = () => {
+            menuRef.current?.clearFocus();
+        };
+        window.addEventListener('click', handler);
+        return () => {
+            window.removeEventListener('click', handler);
+        };
+    }, []);
+
+    return (
+        <React.Fragment>
+            <div
+                className={b('menu')}
+                onClick={() => {
+                    if (searchInputRef.current) {
+                        searchInputRef.current.focus();
+                    }
+                }}
+                onKeyDown={(event) => {
+                    if (menuRef.current) {
+                        if (menuRef.current.handleKeyDown(event)) {
+                            event.preventDefault();
+                        }
+                    }
+                }}
+            >
+                <Title>{title}</Title>
+                <SettingsSearch
+                    inputRef={searchInputRef}
+                    className={b('search')}
+                    initialValue={initialSearch}
+                    selection={selection}
+                    onChange={setSearch}
+                    placeholder={filterPlaceholder}
+                    autoFocus
+                />
+                <SettingsMenu
+                    ref={menuRef}
+                    items={menu}
+                    onChange={onPageChange}
+                    activeItemId={activePage}
+                />
+            </div>
+            {children}
+        </React.Fragment>
+    );
+}
+
 function SettingsContent({
     initialPage,
     initialSearch,
@@ -87,23 +198,7 @@ function SettingsContent({
         selectionInitialPage ||
             (initialPage && pageKeys.includes(initialPage) ? initialPage : undefined),
     );
-    const searchInputRef = React.useRef<HTMLInputElement>(null);
-    const menuRef = React.useRef<SettingsMenuInstance>(null);
     const isMobile = view === 'mobile';
-
-    React.useEffect(() => {
-        menuRef.current?.clearFocus();
-    }, [search]);
-
-    React.useEffect(() => {
-        const handler = () => {
-            menuRef.current?.clearFocus();
-        };
-        window.addEventListener('click', handler);
-        return () => {
-            window.removeEventListener('click', handler);
-        };
-    }, []);
 
     let activePage = selectedPage;
 
@@ -111,20 +206,28 @@ function SettingsContent({
         activePage = Object.values(pages).find(({hidden}) => !hidden)?.id;
     }
 
-    const handlePageChange = (newPage: string | undefined) => {
-        setCurrentPage((prevPage) => {
-            if (prevPage !== newPage && !isFakePage(newPage)) {
-                onPageChange?.(newPage);
-            }
-            return newPage;
-        });
-    };
+    const {isAllSearchPage, hasAllSearchResultsPage, allSearchResultsId} = useAllResultsPage({
+        pages,
+    });
 
-    const {isAllSearchPage} = useAllResultsPage({pages, handlePageChange});
+    const handlePageChange = React.useCallback(
+        (newPage: string | undefined) => {
+            setCurrentPage((prevPage) => {
+                if (prevPage !== newPage && !isAllSearchPage(newPage)) {
+                    onPageChange?.(newPage);
+                }
+                return newPage;
+            });
+        },
+        [isAllSearchPage, onPageChange],
+    );
 
-    function isFakePage(page: string | undefined) {
-        return isAllSearchPage(page);
-    }
+    React.useEffect(() => {
+        if (hasAllSearchResultsPage) {
+            handlePageChange(allSearchResultsId);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [hasAllSearchResultsPage]);
 
     React.useEffect(() => {
         if (activePage !== selectedPage) {
@@ -143,74 +246,73 @@ function SettingsContent({
         }
     }, [selected.selectedRef]);
 
+    const tabContent = React.useMemo(
+        () => (
+            <div className={b('page')}>
+                <SettingsPageComponent
+                    menu={menu}
+                    pages={pages}
+                    selected={selected}
+                    search={search}
+                    isMobile={isMobile}
+                    page={activePage}
+                    emptyPlaceholder={emptyPlaceholder}
+                    renderNotFound={renderNotFound}
+                    onClose={onClose}
+                />
+            </div>
+        ),
+        [
+            activePage,
+            emptyPlaceholder,
+            isMobile,
+            menu,
+            onClose,
+            pages,
+            renderNotFound,
+            search,
+            selected,
+        ],
+    );
+
+    const contentInnerProps = React.useMemo<SettingsContentInnerProps>(
+        () => ({
+            menu,
+            onPageChange: handlePageChange,
+            selected,
+            setSearch,
+            activePage,
+            filterPlaceholder,
+            selection,
+            initialSearch,
+            title,
+            search,
+        }),
+        [
+            activePage,
+            filterPlaceholder,
+            handlePageChange,
+            initialSearch,
+            menu,
+            search,
+            selected,
+            selection,
+            title,
+        ],
+    );
+
     return (
         <SettingsSelectionContextProvider value={selected}>
             <div className={b({view})}>
                 {isMobile ? (
-                    <React.Fragment>
-                        <SettingsSearch
-                            inputRef={searchInputRef}
-                            className={b('search')}
-                            initialValue={initialSearch}
-                            selection={selection}
-                            onChange={setSearch}
-                            autoFocus={false}
-                            inputSize={'xl'}
-                        />
-                        <SettingsMenuMobile
-                            items={menu}
-                            onChange={handlePageChange}
-                            activeItemId={activePage}
-                            className={b('tabs')}
-                        />
-                    </React.Fragment>
+                    <SettingsContentInnerMobile {...contentInnerProps}>
+                        {tabContent}
+                    </SettingsContentInnerMobile>
                 ) : (
-                    <div
-                        className={b('menu')}
-                        onClick={() => {
-                            if (searchInputRef.current) {
-                                searchInputRef.current.focus();
-                            }
-                        }}
-                        onKeyDown={(event) => {
-                            if (menuRef.current) {
-                                if (menuRef.current.handleKeyDown(event)) {
-                                    event.preventDefault();
-                                }
-                            }
-                        }}
-                    >
-                        <Title>{title}</Title>
-                        <SettingsSearch
-                            inputRef={searchInputRef}
-                            className={b('search')}
-                            initialValue={initialSearch}
-                            selection={selection}
-                            onChange={setSearch}
-                            placeholder={filterPlaceholder}
-                            autoFocus
-                        />
-                        <SettingsMenu
-                            ref={menuRef}
-                            items={menu}
-                            onChange={handlePageChange}
-                            activeItemId={activePage}
-                        />
-                    </div>
+                    <SettingsContentInnerDesktop {...contentInnerProps}>
+                        {tabContent}
+                    </SettingsContentInnerDesktop>
                 )}
-                <div className={b('page')}>
-                    <SettingsPageComponent
-                        menu={menu}
-                        pages={pages}
-                        selected={selected}
-                        search={search}
-                        isMobile={isMobile}
-                        page={activePage}
-                        emptyPlaceholder={emptyPlaceholder}
-                        renderNotFound={renderNotFound}
-                        onClose={onClose}
-                    />
-                </div>
             </div>
         </SettingsSelectionContextProvider>
     );

--- a/src/components/Settings/SettingsMenu/SettingsMenu.tsx
+++ b/src/components/Settings/SettingsMenu/SettingsMenu.tsx
@@ -91,6 +91,7 @@ function renderMenuItem(
     return (
         <span
             key={item.title}
+            {...item.menuItemAriaProps}
             className={b('item', {
                 selected: activeItemId === item.id,
                 disabled: item.disabled,

--- a/src/components/Settings/SettingsMenuMobile/SettingsMenuMobile.tsx
+++ b/src/components/Settings/SettingsMenuMobile/SettingsMenuMobile.tsx
@@ -1,41 +1,38 @@
 import React from 'react';
 
-import {
-    Tabs as LegacyTabs,
-    type TabsItemProps as LegacyTabsItemProps,
-} from '@gravity-ui/uikit/legacy';
+import {Tab, TabList, TabProps} from '@gravity-ui/uikit';
 
 import {createBlock} from '../../utils/cn';
-import {SettingsMenuProps} from '../types';
+import {SettingsMenuMobileProps} from '../types';
 
 import styles from './SettingsMenuMobile.module.scss';
 
 const b = createBlock('settings-menu-mobile', styles);
 
-export const SettingsMenuMobile = ({
-    items,
-    onChange,
-    activeItemId,
-    className,
-}: SettingsMenuProps) => {
+export const SettingsMenuMobile = ({items, className}: SettingsMenuMobileProps) => {
     const ref = React.useRef<HTMLDivElement>(null);
 
     const tabItems = React.useMemo(() => {
-        const result: LegacyTabsItemProps[] = [];
+        const result: TabProps[] = [];
 
         items.forEach((firstLevelItem) => {
             if ('groupTitle' in firstLevelItem) {
                 result.push(
                     ...firstLevelItem.items.map(({id, title, disabled, withBadge}) => ({
-                        id,
-                        title,
+                        value: id,
+                        children: title,
                         disabled,
                         className: b('item', {badge: withBadge}),
                     })),
                 );
             } else {
                 const {id, title, disabled, withBadge} = firstLevelItem;
-                result.push({id, title, disabled, className: b('item', {badge: withBadge})});
+                result.push({
+                    value: id,
+                    children: title,
+                    disabled,
+                    className: b('item', {badge: withBadge}),
+                });
             }
         });
         return result;
@@ -47,13 +44,11 @@ export const SettingsMenuMobile = ({
 
     return (
         <div ref={ref} onTouchMove={handleTouchMove}>
-            <LegacyTabs
-                items={tabItems}
-                className={b(null, className)}
-                size="l"
-                activeTab={activeItemId}
-                onSelectTab={onChange}
-            />
+            <TabList size="l" className={b(null, className)}>
+                {tabItems.map((item) => (
+                    <Tab key={item.value} {...item} />
+                ))}
+            </TabList>
         </div>
     );
 };

--- a/src/components/Settings/SettingsSearch/AllResultsPage.tsx
+++ b/src/components/Settings/SettingsSearch/AllResultsPage.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {ListUl} from '@gravity-ui/icons';
 import last from 'lodash/last';
 
@@ -14,25 +12,14 @@ import i18n from '../i18n';
 
 const allSearchResultsId = 'allSearchResults';
 
-export function useAllResultsPage({
-    pages,
-    handlePageChange,
-}: {
-    pages: SettingsDescription['pages'];
-    handlePageChange: (page: string | undefined) => void;
-}) {
+export function useAllResultsPage({pages}: {pages: SettingsDescription['pages']}) {
     const allSearchResultsPage = pages[allSearchResultsId];
     const hasAllSearchResultsPage = Boolean(allSearchResultsPage);
 
-    React.useEffect(() => {
-        if (hasAllSearchResultsPage) {
-            handlePageChange(allSearchResultsId);
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [hasAllSearchResultsPage]);
-
     return {
         isAllSearchPage: (page: string | undefined) => page === allSearchResultsId,
+        hasAllSearchResultsPage,
+        allSearchResultsId,
     };
 }
 

--- a/src/components/Settings/collect-settings.ts
+++ b/src/components/Settings/collect-settings.ts
@@ -5,6 +5,7 @@ import {IconProps} from '@gravity-ui/uikit';
 import {SettingsSelection} from './Selection/types';
 import {getSettingsDescriptionWithAllResultsPage} from './SettingsSearch/AllResultsPage';
 import {escapeStringForRegExp, invariant} from './helpers';
+import type {SettingsMenuItemAriaProps} from './types';
 
 export type SettingsMenu = (SettingsMenuGroup | SettingsMenuItem)[];
 
@@ -19,6 +20,7 @@ export interface SettingsMenuItem {
     icon?: IconProps;
     withBadge?: boolean;
     disabled?: boolean;
+    menuItemAriaProps?: SettingsMenuItemAriaProps;
 }
 
 export interface SettingsPage {
@@ -149,6 +151,7 @@ function getSettingsFromChildrenRecursive(
                     icon: element.props.icon,
                     withBadge: pages[pageId].withBadge,
                     disabled: pages[pageId].hidden,
+                    menuItemAriaProps: element.props.menuItemAriaProps,
                 });
             }
         }

--- a/src/components/Settings/index.ts
+++ b/src/components/Settings/index.ts
@@ -9,4 +9,5 @@ export type {
     SettingsPageProps,
     SettingsSectionProps,
     SettingsItemProps,
+    SettingsMenuItemAriaProps,
 } from './types';

--- a/src/components/Settings/types.ts
+++ b/src/components/Settings/types.ts
@@ -28,6 +28,11 @@ export interface SettingsMenuProps {
     className?: string;
 }
 
+export type SettingsMenuMobileProps = Omit<
+    SettingsMenuProps,
+    'activeItemId' | 'focusItemId' | 'onChange'
+>;
+
 export interface SettingsProps {
     children: React.ReactNode;
     title?: string;

--- a/src/components/Settings/types.ts
+++ b/src/components/Settings/types.ts
@@ -10,12 +10,16 @@ interface GroupItem {
     items: Item[];
 }
 
+export type SettingsMenuItemAriaProps = React.AriaAttributes &
+    Pick<React.HTMLAttributes<HTMLSpanElement>, 'role'>;
+
 export interface Item {
     id: string;
     title: string;
     icon?: IconProps;
     disabled?: boolean;
     withBadge?: boolean;
+    menuItemAriaProps?: SettingsMenuItemAriaProps;
 }
 
 type SettingsMenuItems = (GroupItem | Item)[];
@@ -63,6 +67,8 @@ export interface SettingsPageProps {
     title?: string;
     icon?: IconProps;
     children: React.ReactNode;
+    /** Merged onto the left menu row in desktop Settings (`SettingsMenu`). */
+    menuItemAriaProps?: SettingsMenuItemAriaProps;
 }
 
 export interface SettingsSectionProps {

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -4,6 +4,9 @@ import {AlertProps, IconProps, QAProps} from '@gravity-ui/uikit';
 
 export type MenuItemType = 'regular' | 'action' | 'divider';
 
+export type AsideHeaderMenuItemAriaProps = React.AriaAttributes &
+    Pick<React.HTMLAttributes<HTMLButtonElement>, 'role'>;
+
 export type OpenModalSubscriber = (open: boolean) => void;
 
 export interface MakeItemParams {
@@ -58,6 +61,7 @@ export interface MenuItem extends QAProps {
      */
     groupId?: string;
     className?: string;
+    menuItemAriaProps?: AsideHeaderMenuItemAriaProps;
 }
 
 export interface MenuGroup {


### PR DESCRIPTION
## Summary
- port Settings TabList migration from main (#624)
- port SettingsMenu/menu item aria attributes from main (#629)
- keep the v6 compact API while adding aria-label fallback and menuItemAriaProps

## Validation
- npm ci
- npm test
- npm run typecheck

This branch is rebased on the fresh v6 after the Storybook 9 PR merge.