### PR TITLE
ci: add explicit major guard for previous stable release

### DIFF
--- a/.github/workflows/release-previous-stable.yml
+++ b/.github/workflows/release-previous-stable.yml
@@ -7,12 +7,23 @@ name: Release previous major version
 on:
   workflow_dispatch:
     inputs:
+      major_version:
+        type: string
+        required: true
+        description: Major version to release, for example 4 or v4
       version_type:
         type: choice
+        required: true
         description: Select type of version for release
         options:
           - patch
           - minor
+      allow_package_major_mismatch:
+        type: boolean
+        required: false
+        default: false
+        # WARNING: when enabled, workflow may publish code from the selected branch under the requested major even if package.json belongs to another major.
+        description: Allow publishing selected major when package.json has another major
       set_latest:
         type: boolean
         required: false
@@ -22,11 +33,31 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          if [ "${{ github.event.inputs.version_type }}" == "" ]; then
+      - name: Validate inputs
+        run: |
+          if [ "$VERSION_TYPE" == "" ]; then
               echo "version_type must be defined"
               exit 1
           fi
+          if [ "$VERSION_TYPE" != "patch" ] && [ "$VERSION_TYPE" != "minor" ]; then
+              echo "version_type must be patch or minor"
+              exit 1
+          fi
+          if [ "$MAJOR_VERSION" == "" ]; then
+              echo "major_version must be defined"
+              exit 1
+          fi
+          if [[ ! "$MAJOR_VERSION" =~ ^v?(0|[1-9][0-9]*)$ ]]; then
+              echo "major_version must match ^v?(0|[1-9][0-9]*)$"
+              exit 1
+          fi
+          selected_major="${MAJOR_VERSION#v}"
+          echo "MAJOR_VERSION_NORMALIZED=${selected_major}" >> "$GITHUB_ENV"
+          echo "Selected major version: ${selected_major}"
+        shell: bash
+        env:
+          MAJOR_VERSION: ${{ github.event.inputs.major_version }}
+          VERSION_TYPE: ${{ github.event.inputs.version_type }}
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GRAVITY_UI_BOT_GITHUB_TOKEN }}
@@ -34,6 +65,25 @@ jobs:
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'
+      - name: Validate package major
+        run: |
+          package_version=$(node -p "require('./package.json').version")
+          if [ "$MAJOR_VERSION_NORMALIZED" == "" ]; then
+              echo "MAJOR_VERSION_NORMALIZED must be defined"
+              exit 1
+          fi
+          package_major="${package_version%%.*}"
+          if [ "$MAJOR_VERSION_NORMALIZED" != "$package_major" ] && [ "$ALLOW_PACKAGE_MAJOR_MISMATCH" != "true" ]; then
+              echo "Selected major ${MAJOR_VERSION_NORMALIZED} does not match package.json version ${package_version}."
+              echo "Set allow_package_major_mismatch=true to publish the selected major from this branch anyway."
+              exit 1
+          fi
+          if [ "$MAJOR_VERSION_NORMALIZED" != "$package_major" ]; then
+              echo "WARNING: package.json version ${package_version} does not match selected major ${MAJOR_VERSION_NORMALIZED}; continuing because allow_package_major_mismatch=true."
+          fi
+        shell: bash
+        env:
+          ALLOW_PACKAGE_MAJOR_MISMATCH: ${{ github.event.inputs.allow_package_major_mismatch }}
       - run: npm ci
         shell: bash
       - run: npm test
@@ -48,16 +98,19 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const major = process.env.MAJOR_VERSION_NORMALIZED;
+            if (!major) {
+              throw Error("MAJOR_VERSION_NORMALIZED must be defined");
+            }
             const allVersions = JSON.parse(process.env.VERSIONS).reverse();
             // Filter only stable versions (exclude beta, alpha, rc, etc.)
             const versions = allVersions.filter(v => !v.includes('-'));
             if (versions.length === 0) {
               throw Error("No stable versions found");
             }
-            const currMajor = versions[0].split(".")[0];
-            const prevVersion = versions.find(v => !v.startsWith(`${currMajor}.`));
+            const prevVersion = versions.find(v => v.startsWith(`${major}.`));
             if (!prevVersion) {
-              throw Error("Previous major versions not found");
+              throw Error(`Stable versions for major ${major} not found`);
             }
             const versionParts = prevVersion.split(".");
             if (versionParts.length !== 3) {
@@ -67,8 +120,11 @@ jobs:
               versionParts[1] = `${Number(versionParts[1])+1}`;
               versionParts[2] = "0";
             }
-            else {
+            else if (process.env.VERSION_TYPE === "patch") {
               versionParts[2] = `${Number(versionParts[2])+1}`;
+            }
+            else {
+              throw Error("version_type must be patch or minor");
             }
             const newVersion = versionParts.join(".");
             core.info(`New version: ${newVersion}`);


### PR DESCRIPTION
## Summary
- Cherry-pick `3cbfbc307d8d7e06260d213e75e46a838e5541d9` from `main`.
- Add required `major_version` input for the previous stable release workflow.
- Validate and export the normalized major once, then reuse it in package guard and version calculation.
- Reject leading-zero major input such as `04`, `v04`, and `007`.
- Add package.json major guard with explicit override via `allow_package_major_mismatch`.
- Calculate the next stable version strictly within the selected major.

## Notes
- On `v4`, `package.json` currently has version `5.0.1`, so releasing selected `4.x` from this branch will require `allow_package_major_mismatch=true`.

## Validation
- Parsed workflow YAML with Ruby.
- Simulated shell input validation cases for `4`, `v4`, `abc`, `V4`, `4.x`, `04`, `v04`, and `007`.
- Simulated package-major guard with and without override.
- Simulated JS version calculation for patch/minor and prerelease filtering.
- Ran `git diff --check`.

`actionlint` was not available locally.