### PR TITLE
fix(AsideHeader): center single-item compact popover on the rail item

### DIFF
--- a/src/components/AsideHeader/components/CompositeBar/Item/ItemPopup.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/Item/ItemPopup.tsx
@@ -61,6 +61,8 @@ export const ItemPopup: React.FC<Props> = ({
         [title],
     );
 
+    const isSingleLabel = !title && items.length === 1;
+
     const registerNestedOpen = React.useCallback((delta: number) => {
         nestedOpenCountRef.current = Math.max(0, nestedOpenCountRef.current + delta);
     }, []);
@@ -135,7 +137,7 @@ export const ItemPopup: React.FC<Props> = ({
                 if (nextOpen && disabled) return;
                 wrappedOnOpenChange(nextOpen);
             }}
-            placement="right-start"
+            placement={isSingleLabel ? 'right' : 'right-start'}
             strategy="fixed"
             openDelay={DEFAULT_POPUP_DELAY}
             closeDelay={DEFAULT_POPUP_DELAY}


### PR DESCRIPTION
## Problem

In a collapsed (compact) aside, hovering a menu/footer item shows a single-item label popover. It is vertically misaligned with the hovered item's highlight — the popover row sits a few pixels below the item center.

## Cause

`ItemPopup` always used `placement="right-start"`, top-anchoring the popover to the item. The popover is taller than the item (8px padding + 32px row = 48px vs a 40px item), so with top alignment the row center lands below the item center: 4px off for a 40px item, 8px for a 32px one.

## Fix

When the popover holds a single item with no title (the label tooltip, `items={[item]}`), use centered `placement="right"`. Centering a single centered row on the item aligns it regardless of the item height. Multi-row menus with a title keep `right-start`.

## Verification

Storybook story `components/AsideHeader/Compact`, hovering "Services" (40px item):

| | item center | popover row center |
|---|---|---|
| before | 68 | 72 (−4px) |
| after | 68 | 68 (aligned) |

`eslint` and `tsc --noEmit` pass.
