### PR TITLE
fix: transform action menu items to regular in more popup

### DIFF
--- a/src/components/AsideHeader/components/CompositeBar/Item/ItemPopup.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/Item/ItemPopup.tsx
@@ -84,7 +84,17 @@ export const ItemPopup: React.FC<Props> = ({
         event.stopPropagation();
     }, []);
 
-    if (!items.length) {
+    // Inside a popup list, action items must look like regular menu rows, not floating
+    // action buttons (e.g. when an `action` item overflows into the "More" popup).
+    const popupItems = React.useMemo(
+        () =>
+            items.map((item) =>
+                item.type === 'action' ? {...item, type: 'regular' as const} : item,
+            ),
+        [items],
+    );
+
+    if (!popupItems.length) {
         return children;
     }
 
@@ -93,8 +103,8 @@ export const ItemPopup: React.FC<Props> = ({
             <div className={b('popup-content', {collapsed})} onClick={handlePopupContentClick}>
                 {title && <div className={b('popup-title')}>{title}</div>}
                 <List
-                    items={items}
-                    selectedItemIndex={getSelectedItemIndex(items)}
+                    items={popupItems}
+                    selectedItemIndex={getSelectedItemIndex(popupItems)}
                     itemHeight={getPopupItemHeight}
                     itemsHeight={getPopupItemsHeight}
                     itemClassName={b('root-menu-item', itemClassName)}

--- a/src/components/AsideHeader/components/CompositeBar/__tests__/ItemPopup.test.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/__tests__/ItemPopup.test.tsx
@@ -148,6 +148,21 @@ describe('ItemPopup', () => {
         expect(document.querySelector('[data-qa="icon-item1"]')).toBeNull();
     });
 
+    it('renders action items as regular rows (not floating action buttons) inside the popup', () => {
+        const items: AsideHeaderItem[] = [
+            {id: 'item1', title: 'Create', icon: Gear, type: 'action'},
+        ];
+
+        renderItemPopup({items, open: true});
+
+        expect(screen.getByText('Create')).toBeTruthy();
+        // eslint-disable-next-line testing-library/no-node-access
+        const row = document.querySelector('[data-type]');
+        expect(row).toBeTruthy();
+        expect(row?.getAttribute('data-type')).toBe('regular');
+        expect(row?.className).not.toContain('_type_action');
+    });
+
     it('renders title at the top of the popup when title prop is provided', () => {
         const items: AsideHeaderItem[] = [
             {id: 'item1', title: 'Child 1', icon: Gear},


### PR DESCRIPTION
Problem:

When a menu item with type: 'action' overflowed into the "More" popup (i.e. it was not pinned and not marked with afterMoreButton), it was still rendered as a floating action button inside the popup — with the action styling (shadow, rounded shape, fixed height).

Inside a popup list there should be no floating action button: the item should be transformed into a regular menu row, just like all the other items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Action items in popup menus now render as standard rows instead of action buttons.

* **Tests**
  * Added test to verify action items display correctly in popups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->