### PR TITLE
fix(HotkeysPanel): make hotkeys list scrollable

### DIFF
--- a/src/components/HotkeysPanel/HotkeysPanel.module.scss
+++ b/src/components/HotkeysPanel/HotkeysPanel.module.scss
@@ -12,7 +12,7 @@ $block: '.#{variables.$ns}hotkeys-panel';
 
     &__drawer-item {
         width: var(--hotkeys-panel-width);
-        padding: var(--hotkeys-panel-vertical-padding) 0;
+        padding-top: var(--hotkeys-panel-vertical-padding);
         box-sizing: border-box;
     }
 
@@ -42,6 +42,12 @@ $block: '.#{variables.$ns}hotkeys-panel';
         flex: 1;
         min-height: 0;
         overflow-y: auto;
+
+        &::after {
+            content: '';
+            display: block;
+            height: var(--hotkeys-panel-vertical-padding);
+        }
     }
 
     &__item[class] {

--- a/src/components/HotkeysPanel/HotkeysPanel.module.scss
+++ b/src/components/HotkeysPanel/HotkeysPanel.module.scss
@@ -14,6 +14,11 @@ $block: '.#{variables.$ns}hotkeys-panel';
         width: var(--hotkeys-panel-width);
         padding: var(--hotkeys-panel-vertical-padding) 0;
         box-sizing: border-box;
+    }
+
+    &__drawer-content {
+        height: 100%;
+        min-height: 0;
         display: flex;
         flex-direction: column;
     }
@@ -35,6 +40,7 @@ $block: '.#{variables.$ns}hotkeys-panel';
 
     &__list {
         flex: 1;
+        min-height: 0;
         overflow-y: auto;
     }
 

--- a/src/components/HotkeysPanel/HotkeysPanel.tsx
+++ b/src/components/HotkeysPanel/HotkeysPanel.tsx
@@ -119,7 +119,7 @@ export function HotkeysPanel<T = {}>({
     );
 
     const drawerItemContent = (
-        <React.Fragment>
+        <div className={b('drawer-content')}>
             <Text variant="subheader-3" as={'h2' as const} className={b('title', titleClassName)}>
                 {title}
                 {togglePanelHotkey && <Hotkey value={togglePanelHotkey} platform={platform} />}
@@ -144,7 +144,7 @@ export function HotkeysPanel<T = {}>({
                 emptyPlaceholder={emptyState}
                 {...listProps}
             />
-        </React.Fragment>
+        </div>
     );
 
     const onOpenChange = useCallback(


### PR DESCRIPTION
## Summary

- constrain the HotkeysPanel drawer content to the available height
- allow the hotkeys list flex item to shrink and scroll independently

## Root cause

The drawer content did not provide a height-constrained flex container, and the list flex item kept its default minimum height. With many hotkeys, the list expanded beyond the Drawer instead of scrolling inside it.

## User impact

Long hotkey lists now stay within the Drawer and scroll inside the panel.

## Testing

- `npm run lint:styles -- src/components/HotkeysPanel/HotkeysPanel.module.scss`
- `npm run typecheck`
- `npm test -- --runInBand` (13 suites, 80 tests)

Closes #655


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hotkeys panel layout so its content can shrink correctly within the drawer.
  * Prevented the panel from exceeding available height due to overflowing content.
  * Refined internal spacing and sizing, including clearer top padding and a bottom spacer to keep the hotkeys list aligned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->