### PR TITLE
fix: Avoid rebuilding menu list on tooltip updates

### DIFF
--- a/src/components/AsideHeader/components/CompositeBar/CompositeBar.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/CompositeBar.tsx
@@ -121,17 +121,20 @@ const CompositeBarView: FC<CompositeBarViewProps> = ({
         activeIndex,
         lastClickedItemIndex,
     });
-    multipleTooltipStateRef.current = {
-        active: multipleTooltipActive,
-        activeIndex,
-        lastClickedItemIndex,
-    };
     const onItemClickRef = useRef(onItemClick);
     const onMoreClickRef = useRef(onMoreClick);
     const setMultipleTooltipContextValueRef = useRef(setMultipleTooltipContextValue);
-    onItemClickRef.current = onItemClick;
-    onMoreClickRef.current = onMoreClick;
-    setMultipleTooltipContextValueRef.current = setMultipleTooltipContextValue;
+
+    React.useLayoutEffect(() => {
+        multipleTooltipStateRef.current = {
+            active: multipleTooltipActive,
+            activeIndex,
+            lastClickedItemIndex,
+        };
+        onItemClickRef.current = onItemClick;
+        onMoreClickRef.current = onMoreClick;
+        setMultipleTooltipContextValueRef.current = setMultipleTooltipContextValue;
+    });
 
     React.useEffect(() => {
         function handleBlurWindow() {

--- a/src/components/AsideHeader/components/CompositeBar/CompositeBar.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/CompositeBar.tsx
@@ -42,6 +42,61 @@ type CompositeBarViewProps = CompositeBarProps & {
     collapseItems?: AsideHeaderItem[];
 };
 
+type CompositeBarListProps = {
+    compact: boolean;
+    compositeId?: string;
+    collapseItems?: AsideHeaderItem[];
+    items: AsideHeaderItem[];
+    listRef: React.RefObject<List<AsideHeaderItem>>;
+    multipleTooltip: boolean;
+    onItemClickByIndex: (
+        itemIndex: number,
+        orginalItemClick: AsideHeaderItem['onItemClick'],
+    ) => ItemProps['onItemClick'];
+    onMouseEnterByIndex: (itemIndex: number) => () => void;
+    onMouseLeave: () => void;
+    type: CompositeBarProps['type'];
+};
+
+const CompositeBarList = React.memo(function CompositeBarList({
+    compact,
+    compositeId,
+    collapseItems,
+    items,
+    listRef,
+    multipleTooltip,
+    onItemClickByIndex,
+    onMouseEnterByIndex,
+    onMouseLeave,
+    type,
+}: CompositeBarListProps) {
+    return (
+        <List<AsideHeaderItem>
+            id={compositeId}
+            ref={listRef}
+            items={items}
+            selectedItemIndex={type === 'menu' ? getSelectedItemIndex(items) : undefined}
+            itemHeight={getItemHeight}
+            itemsHeight={getItemsHeight}
+            itemClassName={b('root-menu-item')}
+            virtualized={false}
+            filterable={false}
+            sortable={false}
+            renderItem={(item, _isItemActive, itemIndex) => (
+                <Item
+                    {...item}
+                    enableTooltip={multipleTooltip ? false : item.enableTooltip}
+                    compact={compact}
+                    onMouseEnter={onMouseEnterByIndex(itemIndex)}
+                    onMouseLeave={onMouseLeave}
+                    onItemClick={onItemClickByIndex(itemIndex, item.onItemClick)}
+                    collapseItems={collapseItems}
+                />
+            )}
+        />
+    );
+});
+
 const CompositeBarView: FC<CompositeBarViewProps> = ({
     type,
     items,
@@ -61,6 +116,22 @@ const CompositeBarView: FC<CompositeBarViewProps> = ({
         activeIndex,
         lastClickedItemIndex,
     } = useContext(MultipleTooltipContext);
+    const multipleTooltipStateRef = useRef({
+        active: multipleTooltipActive,
+        activeIndex,
+        lastClickedItemIndex,
+    });
+    multipleTooltipStateRef.current = {
+        active: multipleTooltipActive,
+        activeIndex,
+        lastClickedItemIndex,
+    };
+    const onItemClickRef = useRef(onItemClick);
+    const onMoreClickRef = useRef(onMoreClick);
+    const setMultipleTooltipContextValueRef = useRef(setMultipleTooltipContextValue);
+    onItemClickRef.current = onItemClick;
+    onMoreClickRef.current = onMoreClick;
+    setMultipleTooltipContextValueRef.current = setMultipleTooltipContextValue;
 
     React.useEffect(() => {
         function handleBlurWindow() {
@@ -113,51 +184,48 @@ const CompositeBarView: FC<CompositeBarViewProps> = ({
     const onMouseEnterByIndex = useCallback(
         (itemIndex: number) => () => {
             if (multipleTooltip && document.hasFocus()) {
-                let multipleTooltipActiveValue = multipleTooltipActive;
-                if (!multipleTooltipActive && itemIndex !== lastClickedItemIndex) {
-                    multipleTooltipActiveValue = true;
+                const {
+                    active: multipleTooltipActiveValue,
+                    activeIndex: currentActiveIndex,
+                    lastClickedItemIndex: currentLastClickedItemIndex,
+                } = multipleTooltipStateRef.current;
+                let nextMultipleTooltipActive = multipleTooltipActiveValue;
+                if (!multipleTooltipActiveValue && itemIndex !== currentLastClickedItemIndex) {
+                    nextMultipleTooltipActive = true;
                 }
                 if (
-                    activeIndex === itemIndex &&
-                    multipleTooltipActive === multipleTooltipActiveValue
+                    currentActiveIndex === itemIndex &&
+                    multipleTooltipActiveValue === nextMultipleTooltipActive
                 ) {
                     return;
                 }
-                setMultipleTooltipContextValue({
+                setMultipleTooltipContextValueRef.current({
                     activeIndex: itemIndex,
-                    active: multipleTooltipActiveValue,
+                    active: nextMultipleTooltipActive,
                 });
             }
         },
-        [
-            multipleTooltip,
-            multipleTooltipActive,
-            lastClickedItemIndex,
-            activeIndex,
-            setMultipleTooltipContextValue,
-        ],
+        [multipleTooltip],
     );
 
     const onMouseLeave = useCallback(() => {
         if (compact && document.hasFocus()) {
             ref.current?.activateItem(undefined as unknown as number);
+            const {
+                activeIndex: currentActiveIndex,
+                lastClickedItemIndex: currentLastClickedItemIndex,
+            } = multipleTooltipStateRef.current;
             if (
                 multipleTooltip &&
-                (activeIndex !== undefined || lastClickedItemIndex !== undefined)
+                (currentActiveIndex !== undefined || currentLastClickedItemIndex !== undefined)
             ) {
-                setMultipleTooltipContextValue({
+                setMultipleTooltipContextValueRef.current({
                     activeIndex: undefined,
                     lastClickedItemIndex: undefined,
                 });
             }
         }
-    }, [
-        activeIndex,
-        compact,
-        lastClickedItemIndex,
-        multipleTooltip,
-        setMultipleTooltipContextValue,
-    ]);
+    }, [compact, multipleTooltip]);
 
     const onItemClickByIndex = useCallback(
         (
@@ -165,13 +233,15 @@ const CompositeBarView: FC<CompositeBarViewProps> = ({
             orginalItemClick: AsideHeaderItem['onItemClick'],
         ): ItemProps['onItemClick'] =>
             (item, collapsed, event) => {
+                const {lastClickedItemIndex: currentLastClickedItemIndex} =
+                    multipleTooltipStateRef.current;
                 if (
                     compact &&
                     multipleTooltip &&
-                    itemIndex !== lastClickedItemIndex &&
+                    itemIndex !== currentLastClickedItemIndex &&
                     item.id !== COLLAPSE_ITEM_ID
                 ) {
-                    setMultipleTooltipContextValue({
+                    setMultipleTooltipContextValueRef.current({
                         lastClickedItemIndex: itemIndex,
                         active: false,
                     });
@@ -179,9 +249,9 @@ const CompositeBarView: FC<CompositeBarViewProps> = ({
 
                 // Handle clicks on the "more" button (collapse item)
                 if (item.id === COLLAPSE_ITEM_ID && collapsed) {
-                    onMoreClick?.();
+                    onMoreClickRef.current?.();
                 } else {
-                    onItemClick?.(
+                    onItemClickRef.current?.(
                         {
                             ...item,
                             // For collapsed popup items, preserve the item's own onItemClick
@@ -193,14 +263,7 @@ const CompositeBarView: FC<CompositeBarViewProps> = ({
                     );
                 }
             },
-        [
-            compact,
-            lastClickedItemIndex,
-            multipleTooltip,
-            onItemClick,
-            onMoreClick,
-            setMultipleTooltipContextValue,
-        ],
+        [compact, multipleTooltip],
     );
 
     return (
@@ -210,28 +273,17 @@ const CompositeBarView: FC<CompositeBarViewProps> = ({
                 onMouseEnter={onTooltipMouseEnter}
                 onMouseLeave={onTooltipMouseLeave}
             >
-                <List<AsideHeaderItem>
-                    id={compositeId}
-                    ref={ref}
+                <CompositeBarList
+                    compositeId={compositeId}
+                    type={type}
+                    compact={compact}
                     items={items}
-                    selectedItemIndex={type === 'menu' ? getSelectedItemIndex(items) : undefined}
-                    itemHeight={getItemHeight}
-                    itemsHeight={getItemsHeight}
-                    itemClassName={b('root-menu-item')}
-                    virtualized={false}
-                    filterable={false}
-                    sortable={false}
-                    renderItem={(item, _isItemActive, itemIndex) => (
-                        <Item
-                            {...item}
-                            enableTooltip={multipleTooltip ? false : item.enableTooltip}
-                            compact={compact}
-                            onMouseEnter={onMouseEnterByIndex(itemIndex)}
-                            onMouseLeave={onMouseLeave}
-                            onItemClick={onItemClickByIndex(itemIndex, item.onItemClick)}
-                            collapseItems={collapseItems}
-                        />
-                    )}
+                    listRef={ref}
+                    multipleTooltip={multipleTooltip}
+                    onItemClickByIndex={onItemClickByIndex}
+                    onMouseEnterByIndex={onMouseEnterByIndex}
+                    onMouseLeave={onMouseLeave}
+                    collapseItems={collapseItems}
                 />
             </div>
             {type === 'menu' && multipleTooltip && (

--- a/src/components/AsideHeader/components/CompositeBar/MultipleTooltip/MultipleTooltip.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/MultipleTooltip/MultipleTooltip.tsx
@@ -37,6 +37,7 @@ export const MultipleTooltip: React.FC<MultipleTooltipProps> = ({
             strategy="fixed"
             placement={placement}
             offset={POPUP_OFFSET}
+            returnFocus={false}
         >
             <div className={b()}>
                 <div className={b('items-container')}>

--- a/src/components/AsideHeader/components/CompositeBar/MultipleTooltip/__tests__/MultipleTooltip.test.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/MultipleTooltip/__tests__/MultipleTooltip.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+
+import {Gear} from '@gravity-ui/icons';
+import type {PopupProps} from '@gravity-ui/uikit';
+import {render} from '@testing-library/react';
+
+import {AsideHeaderItem} from 'src/components/AsideHeader/types';
+
+import {MultipleTooltip} from '../MultipleTooltip';
+
+const mockPopup = jest.fn<void, [PopupProps]>();
+
+jest.mock('@gravity-ui/uikit', () => ({
+    Popup: (props: PopupProps) => {
+        mockPopup(props);
+
+        return <>{props.children}</>;
+    },
+}));
+
+describe('MultipleTooltip', () => {
+    it('does not request focus return when it closes', () => {
+        const anchorRef = {current: document.createElement('div')};
+        const items: AsideHeaderItem[] = [{id: 'item', title: 'Item', icon: Gear}];
+
+        render(
+            <MultipleTooltip
+                open
+                anchorRef={anchorRef}
+                placement={['right-start']}
+                items={items}
+            />,
+        );
+
+        expect(mockPopup).toHaveBeenCalledWith(expect.objectContaining({returnFocus: false}));
+    });
+});

--- a/src/components/AsideHeader/components/CompositeBar/__tests__/CompositeBar.test.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/__tests__/CompositeBar.test.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 
 import {Gear} from '@gravity-ui/icons';
-import {ThemeProvider} from '@gravity-ui/uikit';
+import {List, ThemeProvider} from '@gravity-ui/uikit';
 import {fireEvent, render, screen} from '@testing-library/react';
 
 import {AsideHeaderInnerContextProvider} from '../../../AsideHeaderContext';
@@ -25,12 +25,12 @@ const contextValue = {
     allPagesIsAvailable: false,
     onItemClick: () => {},
 } as any;
-
 function renderCompositeBar(props: {
     items: AsideHeaderItem[];
     onItemClick: jest.Mock;
     compact?: boolean;
     menuMoreTitle?: string;
+    multipleTooltip?: boolean;
 }) {
     return render(
         <ThemeProvider theme="light">
@@ -41,6 +41,7 @@ function renderCompositeBar(props: {
                     compact={props.compact ?? false}
                     onItemClick={props.onItemClick}
                     menuMoreTitle={props.menuMoreTitle ?? 'More'}
+                    multipleTooltip={props.multipleTooltip}
                 />
             </AsideHeaderInnerContextProvider>
         </ThemeProvider>,
@@ -48,6 +49,40 @@ function renderCompositeBar(props: {
 }
 
 describe('CompositeBar', () => {
+    it('does not rebuild stable menu items when multiple tooltip state changes', () => {
+        const onItemClick = jest.fn();
+        const items: AsideHeaderItem[] = [
+            {
+                id: 'item1',
+                title: 'Item 1',
+                icon: Gear,
+            },
+            {id: 'item2', title: 'Item 2', icon: Gear},
+        ];
+        const hasFocusSpy = jest.spyOn(document, 'hasFocus').mockReturnValue(true);
+        const listRenderSpy = jest.spyOn(List.prototype, 'render');
+
+        try {
+            renderCompositeBar({items, onItemClick, compact: true, multipleTooltip: true});
+
+            const menuItem = screen.getByRole('button', {name: 'Item 1'});
+            fireEvent.mouseEnter(menuItem);
+            const listRenderCallsAfterHover = listRenderSpy.mock.calls.length;
+
+            fireEvent.click(menuItem);
+
+            expect(listRenderSpy).toHaveBeenCalledTimes(listRenderCallsAfterHover);
+            expect(onItemClick).toHaveBeenCalledWith(
+                expect.objectContaining({id: 'item1'}),
+                false,
+                expect.any(Object),
+            );
+        } finally {
+            hasFocusSpy.mockRestore();
+            listRenderSpy.mockRestore();
+        }
+    });
+
     it('should preserve item.onItemClick when clicking collapsed popup items', () => {
         const onItemClick = jest.fn();
         const dashboardOnItemClick = jest.fn();

--- a/src/components/AsideHeader/components/CompositeBar/__tests__/CompositeBar.test.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/__tests__/CompositeBar.test.tsx
@@ -66,7 +66,16 @@ describe('CompositeBar', () => {
             renderCompositeBar({items, onItemClick, compact: true, multipleTooltip: true});
 
             const menuItem = screen.getByRole('button', {name: 'Item 1'});
-            fireEvent.mouseEnter(menuItem);
+            // Compact Item attaches its hover handler only to this wrapper.
+            // eslint-disable-next-line testing-library/no-node-access
+            const iconWrapper = menuItem.querySelector('[class*="btn-icon"]');
+
+            if (!iconWrapper) {
+                throw new Error('Compact item icon wrapper is missing');
+            }
+
+            fireEvent.mouseEnter(iconWrapper);
+            expect(screen.getAllByText('Item 1')).toHaveLength(2);
             const listRenderCallsAfterHover = listRenderSpy.mock.calls.length;
 
             fireEvent.click(menuItem);

--- a/src/components/AsideHeader/components/CompositeBar/__tests__/CompositeBar.test.tsx
+++ b/src/components/AsideHeader/components/CompositeBar/__tests__/CompositeBar.test.tsx
@@ -49,6 +49,10 @@ function renderCompositeBar(props: {
 }
 
 describe('CompositeBar', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
     it('does not rebuild stable menu items when multiple tooltip state changes', () => {
         const onItemClick = jest.fn();
         const items: AsideHeaderItem[] = [
@@ -59,37 +63,32 @@ describe('CompositeBar', () => {
             },
             {id: 'item2', title: 'Item 2', icon: Gear},
         ];
-        const hasFocusSpy = jest.spyOn(document, 'hasFocus').mockReturnValue(true);
+        jest.spyOn(document, 'hasFocus').mockReturnValue(true);
         const listRenderSpy = jest.spyOn(List.prototype, 'render');
 
-        try {
-            renderCompositeBar({items, onItemClick, compact: true, multipleTooltip: true});
+        renderCompositeBar({items, onItemClick, compact: true, multipleTooltip: true});
 
-            const menuItem = screen.getByRole('button', {name: 'Item 1'});
-            // Compact Item attaches its hover handler only to this wrapper.
-            // eslint-disable-next-line testing-library/no-node-access
-            const iconWrapper = menuItem.querySelector('[class*="btn-icon"]');
+        const menuItem = screen.getByRole('button', {name: 'Item 1'});
+        // Compact Item attaches its hover handler only to this wrapper.
+        // eslint-disable-next-line testing-library/no-node-access
+        const iconWrapper = menuItem.querySelector('[class*="btn-icon"]');
 
-            if (!iconWrapper) {
-                throw new Error('Compact item icon wrapper is missing');
-            }
-
-            fireEvent.mouseEnter(iconWrapper);
-            expect(screen.getAllByText('Item 1')).toHaveLength(2);
-            const listRenderCallsAfterHover = listRenderSpy.mock.calls.length;
-
-            fireEvent.click(menuItem);
-
-            expect(listRenderSpy).toHaveBeenCalledTimes(listRenderCallsAfterHover);
-            expect(onItemClick).toHaveBeenCalledWith(
-                expect.objectContaining({id: 'item1'}),
-                false,
-                expect.any(Object),
-            );
-        } finally {
-            hasFocusSpy.mockRestore();
-            listRenderSpy.mockRestore();
+        if (!iconWrapper) {
+            throw new Error('Compact item icon wrapper is missing');
         }
+
+        fireEvent.mouseEnter(iconWrapper);
+        expect(screen.getAllByText('Item 1')).toHaveLength(2);
+        const listRenderCallsAfterHover = listRenderSpy.mock.calls.length;
+
+        fireEvent.click(menuItem);
+
+        expect(listRenderSpy).toHaveBeenCalledTimes(listRenderCallsAfterHover);
+        expect(onItemClick).toHaveBeenCalledWith(
+            expect.objectContaining({id: 'item1'}),
+            false,
+            expect.any(Object),
+        );
     });
 
     it('should preserve item.onItemClick when clicking collapsed popup items', () => {


### PR DESCRIPTION
## What

- isolate the UIKit List from multiple-tooltip context-only updates
- keep tooltip and click handlers stable while reading their latest values
- preserve hover, click, collapse, and callback behavior

## Testing

- add a regression proving click-only tooltip updates do not rerender List after hover settles
- npm test
- npm run typecheck
- npm run build
- ESLint, Prettier, and git diff checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Composite Bar interaction handling for smoother tooltip, menu-item, and “more” actions.
  * Prevented unnecessary rebuilding of stable menu items when multiple-tooltip settings change.

* **Tests**
  * Added coverage to verify menu items remain stable during tooltip and click interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->